### PR TITLE
Refactor type inference

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -140,8 +140,6 @@ runElara dumpShunted dumpTyped dumpCore = fmap fst <$> finalisePipeline $ do
 cleanup :: IO ()
 cleanup = resetGlobalUniqueSupply
 
-type MainMembers = '[DiagnosticWriter (Doc AnsiStyle), MaybeE]
-
 -- renameModule ::
 --     (Members MainMembers r, Member (Embed IO) r) =>
 --     TopologicalGraph (Module 'Desugared) ->
@@ -164,9 +162,6 @@ type MainMembers = '[DiagnosticWriter (Doc AnsiStyle), MaybeE]
 --         Right (warnings, shunted) -> do
 --             traverse_ report warnings
 --             justE shunted
-
-inferModules :: (Members MainMembers r) => TopologicalGraph (Module 'Shunted) -> Sem r (TopologicalGraph (Module 'Typed))
-inferModules modules = runErrorOrReport (evalState @InferState initialInferState (evalState @Status initialStatus (traverseGraphRevTopologically Infer.inferModule modules)))
 
 loadModule :: IsPipeline r => FilePath -> Sem r (Module 'Desugared)
 loadModule fp = runDesugarPipeline . runParsePipeline . runLexPipeline . runReadFilePipeline $ do

--- a/elara.cabal
+++ b/elara.cabal
@@ -94,6 +94,7 @@ library
       Elara.TypeInfer.Infer
       Elara.TypeInfer.Monotype
       Elara.TypeInfer.Type
+      Elara.TypeInfer.Unique
       Elara.Utils
       Elara.Width
       Polysemy.Lens

--- a/src/Elara/Core.hs
+++ b/src/Elara/Core.hs
@@ -7,11 +7,12 @@ import Data.Data
 import Elara.AST.Name (Qualified)
 import Elara.AST.VarRef (UnlocatedVarRef)
 import Elara.Data.Kind (ElaraKind)
-import Elara.Data.Unique (Unique, UniqueId)
+import Elara.Data.Unique (Unique)
+import Elara.TypeInfer.Unique
 import Prelude hiding (Alt)
 
 data TypeVariable = TypeVariable
-    { tvName :: UniqueId
+    { tvName :: UniqueTyVar
     , tvKind :: ElaraKind
     }
     deriving (Show, Eq, Data)

--- a/src/Elara/Core.hs
+++ b/src/Elara/Core.hs
@@ -7,11 +7,11 @@ import Data.Data
 import Elara.AST.Name (Qualified)
 import Elara.AST.VarRef (UnlocatedVarRef)
 import Elara.Data.Kind (ElaraKind)
-import Elara.Data.Unique (Unique)
+import Elara.Data.Unique (Unique, UniqueId)
 import Prelude hiding (Alt)
 
 data TypeVariable = TypeVariable
-    { tvName :: Unique Text
+    { tvName :: UniqueId
     , tvKind :: ElaraKind
     }
     deriving (Show, Eq, Data)

--- a/src/Elara/Data/Unique.hs
+++ b/src/Elara/Data/Unique.hs
@@ -24,9 +24,6 @@ unsafeMkUnique = Unique
 -- | A @Unique@ where the value is not important.
 newtype UniqueId = UniqueId (Unique ()) deriving (Eq, Ord, Data, Generic)
 
-uniqueIdVal :: UniqueId -> Int
-uniqueIdVal (UniqueId u) = _uniqueId u
-
 instance ToJSON c => ToJSON (Unique c)
 
 instance ToJSON UniqueId

--- a/src/Elara/Prim.hs
+++ b/src/Elara/Prim.hs
@@ -15,6 +15,7 @@ import Elara.TypeInfer.Context (Context, Entry (Annotation))
 import Elara.TypeInfer.Domain (Domain (..))
 import Elara.TypeInfer.Monotype (Scalar (..))
 import Elara.TypeInfer.Type (Type (..))
+import Elara.TypeInfer.Unique (makeUniqueTyVar, makeUniqueTyVarWith)
 import Polysemy
 
 fetchPrimitiveName :: VarName
@@ -70,7 +71,7 @@ primitiveTCContext = do
                 (Custom primRegion "IO" [])
             ]
 
-    primTyVarName <- makeUniqueId
+    primTyVarName <- makeUniqueTyVarWith "a"
     let elaraPrimitive =
             Annotation -- elaraPrimitive :: forall a. String -> a
                 (Global (IgnoreLocation $ mkPrimVarRef (NVarName fetchPrimitiveName)))

--- a/src/Elara/Prim.hs
+++ b/src/Elara/Prim.hs
@@ -10,7 +10,7 @@ import Elara.AST.Region (IgnoreLocation (IgnoreLocation), Located, SourceRegion,
 import Elara.AST.VarRef (VarRef, VarRef' (Global))
 import Elara.Data.Kind (ElaraKind (..))
 
-import Elara.Data.Unique (UniqueGen, makeUnique)
+import Elara.Data.Unique (UniqueGen, makeUnique, makeUniqueId)
 import Elara.TypeInfer.Context (Context, Entry (Annotation))
 import Elara.TypeInfer.Domain (Domain (..))
 import Elara.TypeInfer.Monotype (Scalar (..))
@@ -70,7 +70,7 @@ primitiveTCContext = do
                 (Custom primRegion "IO" [])
             ]
 
-    primTyVarName <- makeUnique "a"
+    primTyVarName <- makeUniqueId
     let elaraPrimitive =
             Annotation -- elaraPrimitive :: forall a. String -> a
                 (Global (IgnoreLocation $ mkPrimVarRef (NVarName fetchPrimitiveName)))

--- a/src/Elara/Prim.hs
+++ b/src/Elara/Prim.hs
@@ -10,10 +10,12 @@ import Elara.AST.Region (IgnoreLocation (IgnoreLocation), Located, SourceRegion,
 import Elara.AST.VarRef (VarRef, VarRef' (Global))
 import Elara.Data.Kind (ElaraKind (..))
 
+import Elara.Data.Unique (UniqueGen, makeUnique)
 import Elara.TypeInfer.Context (Context, Entry (Annotation))
 import Elara.TypeInfer.Domain (Domain (..))
 import Elara.TypeInfer.Monotype (Scalar (..))
 import Elara.TypeInfer.Type (Type (..))
+import Polysemy
 
 fetchPrimitiveName :: VarName
 fetchPrimitiveName = NormalVarName "elaraPrimitive"
@@ -54,7 +56,7 @@ primKindCheckContext =
     fromList ((\x -> (Qualified x primModuleName, TypeKind)) <$> primitiveTypes)
         <> fromList [(Qualified ioName primModuleName, FunctionKind TypeKind TypeKind)] -- Except for IO which is kind Type -> Type
 
-primitiveTCContext :: (Context SourceRegion)
+primitiveTCContext :: Member UniqueGen r => Sem r (Context SourceRegion)
 primitiveTCContext = do
     let easies =
             [ Annotation
@@ -68,10 +70,10 @@ primitiveTCContext = do
                 (Custom primRegion "IO" [])
             ]
 
-    let primTyVarName = "a"
+    primTyVarName <- makeUnique "a"
     let elaraPrimitive =
             Annotation -- elaraPrimitive :: forall a. String -> a
                 (Global (IgnoreLocation $ mkPrimVarRef (NVarName fetchPrimitiveName)))
                 (Forall primRegion primRegion primTyVarName Type (Function primRegion (Scalar primRegion Text) (VariableType primRegion primTyVarName)))
 
-    elaraPrimitive : easies
+    pure (elaraPrimitive : easies)

--- a/src/Elara/TypeInfer/Context.hs
+++ b/src/Elara/TypeInfer/Context.hs
@@ -35,6 +35,7 @@ import Control.Monad qualified as Monad
 import Control.Monad.State.Strict qualified as State
 import Elara.AST.Name (Name)
 import Elara.AST.VarRef (IgnoreLocVarRef)
+import Elara.Data.Unique (Unique, unsafeMkUnique)
 import Elara.TypeInfer.Domain qualified as Domain
 import Elara.TypeInfer.Existential qualified as Existential
 import Elara.TypeInfer.Monotype qualified as Monotype
@@ -66,7 +67,7 @@ data Entry s
       --
       -- >>> pretty @(Entry ()) (Variable Domain.Type "a")
       -- a: Type
-      Variable Domain Text
+      Variable Domain (Unique Text)
     | -- | A bound variable whose type is known
       --
       -- >>>  pretty @(Entry ()) (Annotation (Local (IgnoreLocation (Located undefined (unsafeMkUnique (NVarName "x") 0)))) "a")
@@ -241,11 +242,11 @@ prettyEntry (MarkerFields a) =
 prettyEntry (MarkerAlternatives a) =
     "➤ " <> pretty a <> ": Alternatives"
 
-prettyFieldType :: (Text, Monotype) -> Doc AnsiStyle
+prettyFieldType :: (Unique Text, Monotype) -> Doc AnsiStyle
 prettyFieldType (k, τ) =
     punctuation "," <> " " <> pretty k <> operator ":" <> " " <> pretty τ
 
-prettyAlternativeType :: (Text, Monotype) -> Doc AnsiStyle
+prettyAlternativeType :: (Unique Text, Monotype) -> Doc AnsiStyle
 prettyAlternativeType (k, τ) =
     pretty k <> operator ":" <> " " <> pretty τ
 
@@ -345,7 +346,8 @@ complete context type0 = State.evalState (Monad.foldM snoc type0 context) 0
 
         State.put $! n + 1
 
-        let name = Existential.toVariable (numUnsolved - n)
+        let ex = numUnsolved - n
+        let name = unsafeMkUnique (Existential.toVariable ex) (Existential.existentialVal ex)
 
         let domain = Domain.Type
 
@@ -361,7 +363,8 @@ complete context type0 = State.evalState (Monad.foldM snoc type0 context) 0
 
         State.put $! n + 1
 
-        let name = Existential.toVariable (numUnsolved - n)
+        let ex = numUnsolved - n
+        let name = unsafeMkUnique (Existential.toVariable ex) (Existential.existentialVal ex)
 
         let domain = Domain.Fields
 
@@ -377,7 +380,8 @@ complete context type0 = State.evalState (Monad.foldM snoc type0 context) 0
 
         State.put $! n + 1
 
-        let name = Existential.toVariable (numUnsolved - n)
+        let ex = numUnsolved - n
+        let name = unsafeMkUnique (Existential.toVariable ex) (Existential.existentialVal ex)
 
         let domain = Domain.Alternatives
 

--- a/src/Elara/TypeInfer/Error.hs
+++ b/src/Elara/TypeInfer/Error.hs
@@ -7,6 +7,7 @@ import Elara.AST.Shunted
 import Elara.AST.VarRef (IgnoreLocVarRef)
 import Elara.Data.Kind.Infer (KindInferError)
 import Elara.Data.Pretty
+import Elara.Data.Unique
 import Elara.Error (ReportableError (report), writeReport)
 import Elara.TypeInfer.Context (Context)
 import Elara.TypeInfer.Existential
@@ -36,7 +37,7 @@ data TypeInferenceError
     | MissingVariable (Existential Monotype) (Context SourceRegion)
     | --
       NotFunctionType SourceRegion (Type SourceRegion)
-    | NotNecessarilyFunctionType SourceRegion Text
+    | NotNecessarilyFunctionType SourceRegion (Unique Text)
     | --
       NotAlternativesSubtype SourceRegion (Existential Monotype.Union) (Type.Union SourceRegion)
     | NotFieldsSubtype SourceRegion (Existential Monotype.Record) (Type.Record SourceRegion)
@@ -44,9 +45,9 @@ data TypeInferenceError
     | NotUnionSubtype SourceRegion (Type SourceRegion) SourceRegion (Type SourceRegion)
     | NotSubtype SourceRegion (Type SourceRegion) SourceRegion (Type SourceRegion)
     | --
-      UnboundAlternatives SourceRegion Text
-    | UnboundFields SourceRegion Text
-    | UnboundTypeVariable SourceRegion Text (Context SourceRegion)
+      UnboundAlternatives SourceRegion (Unique Text)
+    | UnboundFields SourceRegion (Unique Text)
+    | UnboundTypeVariable SourceRegion (Unique Text) (Context SourceRegion)
     | UnboundVariable
         SourceRegion
         -- ^ Location of the variable that caused the error
@@ -54,8 +55,8 @@ data TypeInferenceError
         (Context SourceRegion)
     | UnboundConstructor (IgnoreLocVarRef Name) (Context SourceRegion)
     | --
-      RecordTypeMismatch (Type SourceRegion) (Type SourceRegion) (Map.Map Text (Type SourceRegion)) (Map.Map Text (Type SourceRegion))
-    | UnionTypeMismatch (Type SourceRegion) (Type SourceRegion) (Map.Map Text (Type SourceRegion)) (Map.Map Text (Type SourceRegion))
+      RecordTypeMismatch (Type SourceRegion) (Type SourceRegion) (Map.Map (Unique Text) (Type SourceRegion)) (Map.Map (Unique Text) (Type SourceRegion))
+    | UnionTypeMismatch (Type SourceRegion) (Type SourceRegion) (Map.Map (Unique Text) (Type SourceRegion)) (Map.Map (Unique Text) (Type SourceRegion))
     | --
       UserDefinedTypeNotInContext SourceRegion ShuntedType (Context SourceRegion)
     | KindInferError KindInferError

--- a/src/Elara/TypeInfer/Error.hs
+++ b/src/Elara/TypeInfer/Error.hs
@@ -37,7 +37,7 @@ data TypeInferenceError
     | MissingVariable (Existential Monotype) (Context SourceRegion)
     | --
       NotFunctionType SourceRegion (Type SourceRegion)
-    | NotNecessarilyFunctionType SourceRegion (Unique Text)
+    | NotNecessarilyFunctionType SourceRegion UniqueId
     | --
       NotAlternativesSubtype SourceRegion (Existential Monotype.Union) (Type.Union SourceRegion)
     | NotFieldsSubtype SourceRegion (Existential Monotype.Record) (Type.Record SourceRegion)
@@ -45,9 +45,9 @@ data TypeInferenceError
     | NotUnionSubtype SourceRegion (Type SourceRegion) SourceRegion (Type SourceRegion)
     | NotSubtype SourceRegion (Type SourceRegion) SourceRegion (Type SourceRegion)
     | --
-      UnboundAlternatives SourceRegion (Unique Text)
-    | UnboundFields SourceRegion (Unique Text)
-    | UnboundTypeVariable SourceRegion (Unique Text) (Context SourceRegion)
+      UnboundAlternatives SourceRegion UniqueId
+    | UnboundFields SourceRegion UniqueId
+    | UnboundTypeVariable SourceRegion UniqueId (Context SourceRegion)
     | UnboundVariable
         SourceRegion
         -- ^ Location of the variable that caused the error
@@ -55,8 +55,8 @@ data TypeInferenceError
         (Context SourceRegion)
     | UnboundConstructor (IgnoreLocVarRef Name) (Context SourceRegion)
     | --
-      RecordTypeMismatch (Type SourceRegion) (Type SourceRegion) (Map.Map (Unique Text) (Type SourceRegion)) (Map.Map (Unique Text) (Type SourceRegion))
-    | UnionTypeMismatch (Type SourceRegion) (Type SourceRegion) (Map.Map (Unique Text) (Type SourceRegion)) (Map.Map (Unique Text) (Type SourceRegion))
+      RecordTypeMismatch (Type SourceRegion) (Type SourceRegion) (Map.Map UniqueId (Type SourceRegion)) (Map.Map UniqueId (Type SourceRegion))
+    | UnionTypeMismatch (Type SourceRegion) (Type SourceRegion) (Map.Map UniqueId (Type SourceRegion)) (Map.Map UniqueId (Type SourceRegion))
     | --
       UserDefinedTypeNotInContext SourceRegion ShuntedType (Context SourceRegion)
     | KindInferError KindInferError

--- a/src/Elara/TypeInfer/Error.hs
+++ b/src/Elara/TypeInfer/Error.hs
@@ -15,6 +15,7 @@ import Elara.TypeInfer.Monotype (Monotype)
 import Elara.TypeInfer.Monotype qualified as Monotype
 import Elara.TypeInfer.Type (Type)
 import Elara.TypeInfer.Type qualified as Type
+import Elara.TypeInfer.Unique
 import Error.Diagnose (Marker (Where), Report (Err))
 import Print
 
@@ -37,7 +38,7 @@ data TypeInferenceError
     | MissingVariable (Existential Monotype) (Context SourceRegion)
     | --
       NotFunctionType SourceRegion (Type SourceRegion)
-    | NotNecessarilyFunctionType SourceRegion UniqueId
+    | NotNecessarilyFunctionType SourceRegion UniqueTyVar
     | --
       NotAlternativesSubtype SourceRegion (Existential Monotype.Union) (Type.Union SourceRegion)
     | NotFieldsSubtype SourceRegion (Existential Monotype.Record) (Type.Record SourceRegion)
@@ -45,9 +46,9 @@ data TypeInferenceError
     | NotUnionSubtype SourceRegion (Type SourceRegion) SourceRegion (Type SourceRegion)
     | NotSubtype SourceRegion (Type SourceRegion) SourceRegion (Type SourceRegion)
     | --
-      UnboundAlternatives SourceRegion UniqueId
-    | UnboundFields SourceRegion UniqueId
-    | UnboundTypeVariable SourceRegion UniqueId (Context SourceRegion)
+      UnboundAlternatives SourceRegion UniqueTyVar
+    | UnboundFields SourceRegion UniqueTyVar
+    | UnboundTypeVariable SourceRegion UniqueTyVar (Context SourceRegion)
     | UnboundVariable
         SourceRegion
         -- ^ Location of the variable that caused the error
@@ -55,8 +56,8 @@ data TypeInferenceError
         (Context SourceRegion)
     | UnboundConstructor (IgnoreLocVarRef Name) (Context SourceRegion)
     | --
-      RecordTypeMismatch (Type SourceRegion) (Type SourceRegion) (Map.Map UniqueId (Type SourceRegion)) (Map.Map UniqueId (Type SourceRegion))
-    | UnionTypeMismatch (Type SourceRegion) (Type SourceRegion) (Map.Map UniqueId (Type SourceRegion)) (Map.Map UniqueId (Type SourceRegion))
+      RecordTypeMismatch (Type SourceRegion) (Type SourceRegion) (Map.Map UniqueTyVar (Type SourceRegion)) (Map.Map UniqueTyVar (Type SourceRegion))
+    | UnionTypeMismatch (Type SourceRegion) (Type SourceRegion) (Map.Map UniqueTyVar (Type SourceRegion)) (Map.Map UniqueTyVar (Type SourceRegion))
     | --
       UserDefinedTypeNotInContext SourceRegion ShuntedType (Context SourceRegion)
     | KindInferError KindInferError

--- a/src/Elara/TypeInfer/Existential.hs
+++ b/src/Elara/TypeInfer/Existential.hs
@@ -40,3 +40,6 @@ toVariable (UnsafeExistential n) = Text.cons prefix suffix
     prefix = chr (ord 'a' + r)
 
     suffix = if q == 0 then "" else show (q - 1)
+
+existentialVal :: Existential a -> Int
+existentialVal (UnsafeExistential n) = n

--- a/src/Elara/TypeInfer/Existential.hs
+++ b/src/Elara/TypeInfer/Existential.hs
@@ -4,10 +4,12 @@ module Elara.TypeInfer.Existential where
 
 import Elara.Data.Pretty (Pretty (..))
 
+import Control.Lens ((^.))
 import Data.Aeson (ToJSON)
 import Data.Data (Data)
 import Data.Text qualified as Text
 import Elara.Data.Unique
+import Elara.TypeInfer.Unique (UniqueTyVar)
 
 {- | An existential variable
     The type variable is used to track what type of existential variable we're
@@ -17,7 +19,7 @@ import Elara.Data.Unique
     * @`Existential` "Grace.Monotype".Union@ - An existential alternatives
       variable
 -}
-newtype Existential a = UnsafeExistential UniqueId
+newtype Existential a = UnsafeExistential UniqueTyVar
     deriving (Eq, Ord, Data)
     deriving newtype (Show, ToJSON)
 
@@ -34,10 +36,13 @@ instance Pretty (Existential a) where
     "a0"
 -}
 toVariable :: Existential a -> Text
-toVariable (UnsafeExistential n) = Text.cons prefix suffix
-  where
-    (q, r) = uniqueIdVal n `quotRem` 26
+toVariable (UnsafeExistential n) =
+    case n ^. uniqueVal of
+        Just name -> name
+        Nothing -> Text.cons prefix suffix
+          where
+            (q, r) = (n ^. uniqueId) `quotRem` 26
 
-    prefix = chr (ord 'a' + r)
+            prefix = chr (ord 'a' + r)
 
-    suffix = if q == 0 then "" else show (q - 1)
+            suffix = if q == 0 then "" else show (q - 1)

--- a/src/Elara/TypeInfer/Existential.hs
+++ b/src/Elara/TypeInfer/Existential.hs
@@ -7,6 +7,7 @@ import Elara.Data.Pretty (Pretty (..))
 import Data.Aeson (ToJSON)
 import Data.Data (Data)
 import Data.Text qualified as Text
+import Elara.Data.Unique
 
 {- | An existential variable
     The type variable is used to track what type of existential variable we're
@@ -16,8 +17,8 @@ import Data.Text qualified as Text
     * @`Existential` "Grace.Monotype".Union@ - An existential alternatives
       variable
 -}
-newtype Existential a = UnsafeExistential Int
-    deriving (Eq, Num, Ord, Data)
+newtype Existential a = UnsafeExistential UniqueId
+    deriving (Eq, Ord, Data)
     deriving newtype (Show, ToJSON)
 
 instance Pretty (Existential a) where
@@ -35,11 +36,8 @@ instance Pretty (Existential a) where
 toVariable :: Existential a -> Text
 toVariable (UnsafeExistential n) = Text.cons prefix suffix
   where
-    (q, r) = n `quotRem` 26
+    (q, r) = uniqueIdVal n `quotRem` 26
 
     prefix = chr (ord 'a' + r)
 
     suffix = if q == 0 then "" else show (q - 1)
-
-existentialVal :: Existential a -> Int
-existentialVal (UnsafeExistential n) = n

--- a/src/Elara/TypeInfer/Infer.hs
+++ b/src/Elara/TypeInfer/Infer.hs
@@ -47,6 +47,7 @@ import Elara.TypeInfer.Domain qualified as Domain
 import Elara.TypeInfer.Error
 import Elara.TypeInfer.Monotype qualified as Monotype
 import Elara.TypeInfer.Type qualified as Type
+import Elara.TypeInfer.Unique
 import Polysemy
 import Polysemy.Error (Error, throw)
 import Polysemy.State (State)
@@ -77,7 +78,7 @@ Nothing `orDie` e = throw e
 
 -- | Generate a fresh existential variable (of any type)
 fresh :: (Member UniqueGen r) => Sem r (Existential a)
-fresh = UnsafeExistential <$> makeUniqueId
+fresh = UnsafeExistential <$> makeUniqueTyVar
 
 -- Unlike the original paper, we don't explicitly thread the `Context` around.
 -- Instead, we modify the ambient state using the following utility functions:

--- a/src/Elara/TypeInfer/Monotype.hs
+++ b/src/Elara/TypeInfer/Monotype.hs
@@ -18,6 +18,7 @@ module Elara.TypeInfer.Monotype (
 import Data.Aeson (ToJSON)
 import Data.Data (Data)
 import Elara.Data.Pretty (Pretty (..))
+import Elara.Data.Unique
 import Elara.TypeInfer.Existential (Existential)
 
 {- $setup
@@ -32,7 +33,7 @@ import Elara.TypeInfer.Existential (Existential)
     `Grace.Type.Forall` and `Grace.Type.Exists` constructors
 -}
 data Monotype
-    = VariableType Text
+    = VariableType (Unique Text)
     | UnsolvedType (Existential Monotype)
     | Function Monotype Monotype
     | Optional Monotype
@@ -44,9 +45,6 @@ data Monotype
     deriving stock (Eq, Generic, Show)
 
 instance ToJSON Monotype
-
-instance IsString Monotype where
-    fromString string = VariableType (fromString string)
 
 -- | A scalar type
 data Scalar
@@ -105,7 +103,7 @@ instance Pretty Scalar where
 instance ToJSON Scalar
 
 -- | A monomorphic record type
-data Record = Fields [(Text, Monotype)] RemainingFields
+data Record = Fields [(Unique Text, Monotype)] RemainingFields
     deriving stock (Eq, Generic, Show)
 
 instance ToJSON Record
@@ -121,11 +119,11 @@ data RemainingFields
       UnsolvedFields (Existential Record)
     | -- | Same as `UnsolvedFields`, except that the user has given the fields
       --   variable an explicit name in the source code
-      VariableFields Text
+      VariableFields (Unique Text)
     deriving stock (Eq, Generic, Show, Data)
 
 -- | A monomorphic union type
-data Union = Alternatives [(Text, Monotype)] RemainingAlternatives
+data Union = Alternatives [(Unique Text, Monotype)] RemainingAlternatives
     deriving stock (Eq, Generic, Show)
 
 instance ToJSON Union
@@ -140,7 +138,7 @@ data RemainingAlternatives
       UnsolvedAlternatives (Existential Union)
     | -- | Same as `UnsolvedAlternatives`, except that the user has given the
       --   alternatives variable an explicit name in the source code
-      VariableAlternatives Text
+      VariableAlternatives (Unique Text)
     deriving stock (Eq, Generic, Show, Data)
 
 instance ToJSON RemainingAlternatives

--- a/src/Elara/TypeInfer/Monotype.hs
+++ b/src/Elara/TypeInfer/Monotype.hs
@@ -33,7 +33,7 @@ import Elara.TypeInfer.Existential (Existential)
     `Grace.Type.Forall` and `Grace.Type.Exists` constructors
 -}
 data Monotype
-    = VariableType (Unique Text)
+    = VariableType UniqueId
     | UnsolvedType (Existential Monotype)
     | Function Monotype Monotype
     | Optional Monotype
@@ -103,7 +103,7 @@ instance Pretty Scalar where
 instance ToJSON Scalar
 
 -- | A monomorphic record type
-data Record = Fields [(Unique Text, Monotype)] RemainingFields
+data Record = Fields [(UniqueId, Monotype)] RemainingFields
     deriving stock (Eq, Generic, Show)
 
 instance ToJSON Record
@@ -119,11 +119,11 @@ data RemainingFields
       UnsolvedFields (Existential Record)
     | -- | Same as `UnsolvedFields`, except that the user has given the fields
       --   variable an explicit name in the source code
-      VariableFields (Unique Text)
+      VariableFields UniqueId
     deriving stock (Eq, Generic, Show, Data)
 
 -- | A monomorphic union type
-data Union = Alternatives [(Unique Text, Monotype)] RemainingAlternatives
+data Union = Alternatives [(UniqueId, Monotype)] RemainingAlternatives
     deriving stock (Eq, Generic, Show)
 
 instance ToJSON Union
@@ -138,7 +138,7 @@ data RemainingAlternatives
       UnsolvedAlternatives (Existential Union)
     | -- | Same as `UnsolvedAlternatives`, except that the user has given the
       --   alternatives variable an explicit name in the source code
-      VariableAlternatives (Unique Text)
+      VariableAlternatives UniqueId
     deriving stock (Eq, Generic, Show, Data)
 
 instance ToJSON RemainingAlternatives

--- a/src/Elara/TypeInfer/Monotype.hs
+++ b/src/Elara/TypeInfer/Monotype.hs
@@ -20,6 +20,7 @@ import Data.Data (Data)
 import Elara.Data.Pretty (Pretty (..))
 import Elara.Data.Unique
 import Elara.TypeInfer.Existential (Existential)
+import Elara.TypeInfer.Unique
 
 {- $setup
    >>> import qualified Elara.TypeInfer.Monotype as Monotype
@@ -33,7 +34,7 @@ import Elara.TypeInfer.Existential (Existential)
     `Grace.Type.Forall` and `Grace.Type.Exists` constructors
 -}
 data Monotype
-    = VariableType UniqueId
+    = VariableType UniqueTyVar
     | UnsolvedType (Existential Monotype)
     | Function Monotype Monotype
     | Optional Monotype
@@ -103,7 +104,7 @@ instance Pretty Scalar where
 instance ToJSON Scalar
 
 -- | A monomorphic record type
-data Record = Fields [(UniqueId, Monotype)] RemainingFields
+data Record = Fields [(UniqueTyVar, Monotype)] RemainingFields
     deriving stock (Eq, Generic, Show)
 
 instance ToJSON Record
@@ -119,11 +120,11 @@ data RemainingFields
       UnsolvedFields (Existential Record)
     | -- | Same as `UnsolvedFields`, except that the user has given the fields
       --   variable an explicit name in the source code
-      VariableFields UniqueId
+      VariableFields UniqueTyVar
     deriving stock (Eq, Generic, Show, Data)
 
 -- | A monomorphic union type
-data Union = Alternatives [(UniqueId, Monotype)] RemainingAlternatives
+data Union = Alternatives [(UniqueTyVar, Monotype)] RemainingAlternatives
     deriving stock (Eq, Generic, Show)
 
 instance ToJSON Union
@@ -138,7 +139,7 @@ data RemainingAlternatives
       UnsolvedAlternatives (Existential Union)
     | -- | Same as `UnsolvedAlternatives`, except that the user has given the
       --   alternatives variable an explicit name in the source code
-      VariableAlternatives UniqueId
+      VariableAlternatives UniqueTyVar
     deriving stock (Eq, Generic, Show, Data)
 
 instance ToJSON RemainingAlternatives

--- a/src/Elara/TypeInfer/Type.hs
+++ b/src/Elara/TypeInfer/Type.hs
@@ -31,8 +31,9 @@ import Elara.TypeInfer.Domain qualified as Domain
 import Data.Aeson (ToJSON (..), Value (String))
 import Data.Data (Data)
 import Elara.AST.StripLocation (StripLocation (stripLocation))
-import Elara.Data.Unique (Unique, UniqueId, uniqueVal)
+import Elara.Data.Unique (Unique, uniqueVal)
 import Elara.TypeInfer.Monotype qualified as Monotype
+import Elara.TypeInfer.Unique
 import Prettyprinter qualified as Pretty
 import Print (showPrettyUnannotated)
 
@@ -52,7 +53,7 @@ data Type s
       --
       -- >>> pretty @(Type ()) (VariableType () "a")
       -- a
-      VariableType {location :: s, name :: UniqueId}
+      VariableType {location :: s, name :: UniqueTyVar}
     | -- | A placeholder variable whose type has not yet been inferred
       --
       -- >>> pretty @(Type ()) (UnsolvedType () 0)
@@ -62,12 +63,12 @@ data Type s
       --
       -- >>> pretty @(Type ()) (Exists () () "a" Domain.Type "a")
       -- exists (a : Type) . a
-      Exists {location :: s, nameLocation :: s, name :: UniqueId, domain :: Domain, type_ :: Type s}
+      Exists {location :: s, nameLocation :: s, name :: UniqueTyVar, domain :: Domain, type_ :: Type s}
     | -- | Universally quantified type
       --
       -- >>> pretty @(Type ()) (Forall () () "a" Domain.Type "a")
       -- forall (a : Type) . a
-      Forall {location :: s, nameLocation :: s, name :: UniqueId, domain :: Domain, type_ :: Type s}
+      Forall {location :: s, nameLocation :: s, name :: UniqueTyVar, domain :: Domain, type_ :: Type s}
     | -- | Function type
       --
       -- >>> pretty @(Type ()) (Function () "a" "b")
@@ -158,7 +159,7 @@ instance Plated (Type s) where
                 pure Tuple{tupleArguments = newTypeArguments, ..}
 
 -- | A potentially polymorphic record type
-data Record s = Fields [(UniqueId, Type s)] RemainingFields
+data Record s = Fields [(UniqueTyVar, Type s)] RemainingFields
     deriving stock (Eq, Functor, Generic, Show, Data)
 
 instance (Show s, ToJSON s) => ToJSON (Record s)
@@ -167,7 +168,7 @@ instance Show s => Pretty (Record s) where
     pretty = prettyRecordType
 
 -- | A potentially polymorphic union type
-data Union s = Alternatives [(UniqueId, Type s)] RemainingAlternatives
+data Union s = Alternatives [(UniqueTyVar, Type s)] RemainingAlternatives
     deriving stock (Eq, Functor, Generic, Show, Data)
 
 instance (Show s, ToJSON s) => ToJSON (Union s)
@@ -261,7 +262,7 @@ solveAlternatives unsolved (Monotype.Alternatives alternativeMonotypes alternati
 {- | Replace all occurrences of a variable within one `Type` with another `Type`,
     given the variable's label and index
 -}
-substituteType :: UniqueId -> Type s -> Type s -> Type s
+substituteType :: UniqueTyVar -> Type s -> Type s -> Type s
 substituteType a _A type_ =
     case type_ of
         VariableType{..}
@@ -301,7 +302,7 @@ substituteType a _A type_ =
 {- | Replace all occurrences of a variable within one `Type` with another `Type`,
     given the variable's label and index
 -}
-substituteFields :: UniqueId -> Record s -> Type s -> Type s
+substituteFields :: UniqueTyVar -> Record s -> Type s -> Type s
 substituteFields ρ0 r@(Fields kτs ρ1) type_ =
     case type_ of
         VariableType{..} ->
@@ -345,7 +346,7 @@ substituteFields ρ0 r@(Fields kτs ρ1) type_ =
 {- | Replace all occurrences of a variable within one `Type` with another `Type`,
     given the variable's label and index
 -}
-substituteAlternatives :: UniqueId -> Union s -> Type s -> Type s
+substituteAlternatives :: UniqueTyVar -> Union s -> Type s -> Type s
 substituteAlternatives ρ0 r@(Alternatives kτs ρ1) type_ =
     case type_ of
         VariableType{..} ->
@@ -675,14 +676,14 @@ prettyRecordType (Fields (keyType : keyTypes) fields) =
                             <> punctuation "}"
             )
 
-    prettyShortFieldType :: Show s => (UniqueId, Type s) -> Doc AnsiStyle
+    prettyShortFieldType :: Show s => (UniqueTyVar, Type s) -> Doc AnsiStyle
     prettyShortFieldType (key, type_) =
         prettyRecordLabel False key
             <> operator ":"
             <> " "
             <> prettyQuantifiedType type_
 
-    prettyLongFieldType :: Show s => (UniqueId, Type s) -> Doc AnsiStyle
+    prettyLongFieldType :: Show s => (UniqueTyVar, Type s) -> Doc AnsiStyle
     prettyLongFieldType (key, type_) =
         prettyRecordLabel False key
             <> operator ":"
@@ -799,7 +800,7 @@ prettyRecordLabel ::
     -- This is mainly set to `True` when pretty-printing records so that the
     -- output is valid JSON
     Bool ->
-    UniqueId ->
+    UniqueTyVar ->
     Doc AnsiStyle
 prettyRecordLabel alwaysQuote field
     | not alwaysQuote =
@@ -809,7 +810,7 @@ prettyRecordLabel alwaysQuote field
 
 -- | Pretty-print an alternative label
 prettyAlternativeLabel ::
-    UniqueId ->
+    UniqueTyVar ->
     Doc AnsiStyle
 prettyAlternativeLabel alternative =
     label (pretty alternative)

--- a/src/Elara/TypeInfer/Unique.hs
+++ b/src/Elara/TypeInfer/Unique.hs
@@ -1,0 +1,17 @@
+module Elara.TypeInfer.Unique where
+
+import Elara.Data.Unique (Unique, UniqueGen, UniqueId (UniqueId), makeUniqueId)
+import Polysemy
+
+type UniqueTyVar =
+    Unique
+        (Maybe Text) -- Optional name for the type variable. Improves error messages
+
+uniqueIdToTyVar :: UniqueId -> UniqueTyVar
+uniqueIdToTyVar (UniqueId c) = fmap (const Nothing) c
+
+makeUniqueTyVar :: Member UniqueGen r => Sem r UniqueTyVar
+makeUniqueTyVar = uniqueIdToTyVar <$> makeUniqueId
+
+makeUniqueTyVarWith :: Member UniqueGen r => Text -> Sem r UniqueTyVar
+makeUniqueTyVarWith name = const (Just name) <<$>> makeUniqueTyVar

--- a/test/Infer/Common.hs
+++ b/test/Infer/Common.hs
@@ -24,19 +24,20 @@ import Elara.TypeInfer.Domain (Domain)
 import Elara.TypeInfer.Infer qualified as Infer
 import Elara.TypeInfer.Type (Type (..))
 import Elara.TypeInfer.Type qualified as Type
+import Elara.TypeInfer.Unique
 import Polysemy
 import Polysemy.Error (Error, errorToIOFinal)
 import Polysemy.State (State)
 import Print (showPretty)
 import Test.HUnit (assertFailure)
 
-pattern Forall' :: UniqueId -> Domain -> Type () -> Type ()
+pattern Forall' :: UniqueTyVar -> Domain -> Type () -> Type ()
 pattern Forall' name domain t = Forall () () name domain t
 
 pattern Function' :: Type () -> Type () -> Type ()
 pattern Function' a b = Function () a b
 
-pattern VariableType' :: UniqueId -> Type ()
+pattern VariableType' :: UniqueTyVar -> Type ()
 pattern VariableType' name = VariableType () name
 
 pattern Tuple' :: NonEmpty (Type ()) -> Type ()

--- a/test/Infer/Common.hs
+++ b/test/Infer/Common.hs
@@ -30,19 +30,19 @@ import Polysemy.State (State)
 import Print (showPretty)
 import Test.HUnit (assertFailure)
 
-pattern Forall' :: Unique Text -> Domain -> Type () -> Type ()
+pattern Forall' :: UniqueId -> Domain -> Type () -> Type ()
 pattern Forall' name domain t = Forall () () name domain t
 
 pattern Function' :: Type () -> Type () -> Type ()
 pattern Function' a b = Function () a b
 
-pattern VariableType' :: Unique Text -> Type ()
+pattern VariableType' :: UniqueId -> Type ()
 pattern VariableType' name = VariableType () name
 
 pattern Tuple' :: NonEmpty (Type ()) -> Type ()
 pattern Tuple' ts = Type.Tuple () ts
 
-completeInference :: Member (State Infer.Status) r => TypedExpr -> Sem r TypedExpr
+completeInference :: (Member (State Infer.Status) r, Member UniqueGen r) => TypedExpr -> Sem r TypedExpr
 completeInference x = do
     ctx <- Infer.getAll
     completeExpression ctx x

--- a/test/Infer/Common.hs
+++ b/test/Infer/Common.hs
@@ -9,6 +9,7 @@ import Elara.AST.StripLocation
 import Elara.AST.Typed (TypedExpr)
 import Elara.Data.Pretty (Pretty)
 import Elara.Data.TopologicalGraph (createGraph)
+import Elara.Data.Unique
 import Elara.Desugar (desugarExpr, runDesugar, runDesugarPipeline)
 import Elara.Lexer.Pipeline (runLexPipeline)
 import Elara.Lexer.Reader (readTokensWith)
@@ -29,13 +30,13 @@ import Polysemy.State (State)
 import Print (showPretty)
 import Test.HUnit (assertFailure)
 
-pattern Forall' :: Text -> Domain -> Type () -> Type ()
+pattern Forall' :: Unique Text -> Domain -> Type () -> Type ()
 pattern Forall' name domain t = Forall () () name domain t
 
 pattern Function' :: Type () -> Type () -> Type ()
 pattern Function' a b = Function () a b
 
-pattern VariableType' :: Text -> Type ()
+pattern VariableType' :: Unique Text -> Type ()
 pattern VariableType' name = VariableType () name
 
 pattern Tuple' :: NonEmpty (Type ()) -> Type ()


### PR DESCRIPTION
Uses the pre-existing `Unique` system everywhere rather than separate State monads

This makes maintenance easier and should allow for type variables to be handled in Core easier