### PR TITLE
Simple Interpreter Implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ just-flake.just
 # Elara! :D
 build/
 *.class
+elara.log

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -126,10 +126,10 @@ runElara dumpLexed dumpParsed dumpDesugared dumpShunted dumpTyped dumpCore run =
 
     let graph = createGraph (source : stdlibMods)
     coreGraph <- processModules graph (dumpShunted, dumpTyped)
-    -- coreGraph <- uniqueGenToIO $ traverseGraph toANF' coreGraph
-    -- coreGraph <- uniqueGenToIO $ traverseGraph runLiftClosures coreGraph
-    -- runErrorOrReport $ traverseGraph_ typeCheckCoreModule coreGraph
-    -- coreGraph <- traverseGraph (pure . unANF) coreGraph
+    coreGraph <- uniqueGenToIO $ traverseGraph toANF' coreGraph
+    coreGraph <- uniqueGenToIO $ traverseGraph runLiftClosures coreGraph
+    runErrorOrReport $ traverseGraph_ typeCheckCoreModule coreGraph
+    coreGraph <- traverseGraph (pure . unANF) coreGraph
 
     when dumpCore $ do
         liftIO $ dumpGraph coreGraph (view (field' @"name" % to nameText)) ".core.elr"

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -22,7 +22,7 @@ import Elara.Core.Module (CoreModule)
 import Elara.CoreToCore
 import Elara.Data.Pretty
 import Elara.Data.Pretty.Styles qualified as Style
-import Elara.Data.TopologicalGraph (TopologicalGraph, createGraph, mapGraph, traverseGraph, traverseGraphRevTopologically, traverseGraph_)
+import Elara.Data.TopologicalGraph (TopologicalGraph, createGraph, mapGraph, traverseGraph, traverseGraphRevTopologically, traverseGraphRevTopologically_, traverseGraph_)
 import Elara.Data.Unique (resetGlobalUniqueSupply, uniqueGenToIO)
 import Elara.Desugar (desugar, runDesugar, runDesugarPipeline)
 
@@ -135,7 +135,7 @@ runElara dumpLexed dumpParsed dumpDesugared dumpShunted dumpTyped dumpCore run =
         liftIO $ dumpGraph coreGraph (view (field' @"name" % to nameText)) ".core.elr"
 
     runInterpreter $ do
-        for_ coreGraph $ \mod -> do
+        flip traverseGraphRevTopologically_ coreGraph $ \mod -> do
             Interpreter.loadModule mod
         when run $ do
             Interpreter.run

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -32,6 +32,8 @@ import Elara.Core.LiftClosures (runLiftClosures)
 import Elara.Core.TypeCheck (typeCheckCoreModule)
 import Elara.Emit
 import Elara.Error (ReportableError (report), runErrorOrReport, writeReport)
+import Elara.Interpreter (runInterpreter)
+import Elara.Interpreter qualified as Interpreter
 import Elara.Lexer.Pipeline (runLexPipeline)
 import Elara.Lexer.Reader
 import Elara.Logging
@@ -64,8 +66,6 @@ import System.IO (hSetEncoding, openFile, utf8)
 import System.Info (os)
 import System.Process
 import Text.Printf
-import Elara.Interpreter (runInterpreter)
-import qualified Elara.Interpreter as Interpreter
 
 outDirName :: IsString s => s
 outDirName = "build"
@@ -126,10 +126,10 @@ runElara dumpLexed dumpParsed dumpDesugared dumpShunted dumpTyped dumpCore run =
 
     let graph = createGraph (source : stdlibMods)
     coreGraph <- processModules graph (dumpShunted, dumpTyped)
-    coreGraph <- uniqueGenToIO $ traverseGraph toANF' coreGraph
-    coreGraph <- uniqueGenToIO $ traverseGraph runLiftClosures coreGraph
-    runErrorOrReport $ traverseGraph_ typeCheckCoreModule coreGraph
-    coreGraph <- traverseGraph (pure . unANF) coreGraph
+    -- coreGraph <- uniqueGenToIO $ traverseGraph toANF' coreGraph
+    -- coreGraph <- uniqueGenToIO $ traverseGraph runLiftClosures coreGraph
+    -- runErrorOrReport $ traverseGraph_ typeCheckCoreModule coreGraph
+    -- coreGraph <- traverseGraph (pure . unANF) coreGraph
 
     when dumpCore $ do
         liftIO $ dumpGraph coreGraph (view (field' @"name" % to nameText)) ".core.elr"

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -126,11 +126,14 @@ runElara dumpLexed dumpParsed dumpDesugared dumpShunted dumpTyped dumpCore run =
 
     let graph = createGraph (source : stdlibMods)
     coreGraph <- processModules graph (dumpShunted, dumpTyped)
+    when dumpCore $ do
+        liftIO $ dumpGraph coreGraph (view (field' @"name" % to nameText)) ".core.elr"
     coreGraph <- uniqueGenToIO $ traverseGraph toANF' coreGraph
     anfCoreGraph <- uniqueGenToIO $ traverseGraph runLiftClosures coreGraph
 
     coreGraph <- traverseGraph (pure . unANF) anfCoreGraph
 
+    -- override the core graph with the processed one
     when dumpCore $ do
         liftIO $ dumpGraph coreGraph (view (field' @"name" % to nameText)) ".core.elr"
 

--- a/elara.cabal
+++ b/elara.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.38.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -103,6 +103,7 @@ library
       Elara.Rename
       Elara.Shunt
       Elara.ToCore
+      Elara.ToCore.Match
       Elara.TypeInfer
       Elara.TypeInfer.ConstraintGeneration
       Elara.TypeInfer.Convert
@@ -140,8 +141,8 @@ library
       TypeApplications
       PartialTypeSignatures
   ghc-options: -W -Wno-name-shadowing -Wno-partial-type-signatures -Widentities -optP-Wno-nonportable-include-path -fdefer-typed-holes -fno-show-valid-hole-fits -fplugin=Polysemy.Plugin -fwrite-ide-info -hiedir=.hie -threaded -O0 -rtsopts -with-rtsopts=-N
-  build-tools:
-      alex
+  build-tool-depends:
+      alex:alex
   build-depends:
       aeson
     , algebraic-graphs
@@ -157,6 +158,7 @@ library
     , h2jvm
     , hashable
     , lens
+    , matrix
     , megaparsec
     , mtl
     , optics >=0.4.1
@@ -215,6 +217,7 @@ executable elara
     , h2jvm
     , hashable
     , lens
+    , matrix
     , megaparsec
     , mtl
     , optics >=0.4.1
@@ -298,6 +301,7 @@ test-suite elara-test
     , hedgehog
     , hspec-megaparsec
     , lens
+    , matrix
     , megaparsec
     , mtl
     , neat-interpolation

--- a/elara.cabal
+++ b/elara.cabal
@@ -74,6 +74,7 @@ library
       Elara.Error
       Elara.Error.Codes
       Elara.Error.Effect
+      Elara.Interpreter
       Elara.Lexer.Char
       Elara.Lexer.Lexer
       Elara.Lexer.Pipeline

--- a/flake.lock
+++ b/flake.lock
@@ -1,22 +1,5 @@
 {
   "nodes": {
-    "all-cabal-hashes": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1742051834,
-        "narHash": "sha256-nSc9aIuXr7WJ5eCgL0hiblPKIkZ5fvJ8cdyv4XJnajE=",
-        "owner": "commercialhaskell",
-        "repo": "all-cabal-hashes",
-        "rev": "251d18a4dc0c2937e734bd0c9e0a6d182ba66070",
-        "type": "github"
-      },
-      "original": {
-        "owner": "commercialhaskell",
-        "ref": "hackage",
-        "repo": "all-cabal-hashes",
-        "type": "github"
-      }
-    },
     "diagnose": {
       "flake": false,
       "locked": {
@@ -36,11 +19,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
         "type": "github"
       },
       "original": {
@@ -54,11 +37,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1741352980,
-        "narHash": "sha256-+u2UunDA4Cl5Fci3m7S643HzKmIDAe+fiXrLqYsR2fs=",
+        "lastModified": 1754487366,
+        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f4330d22f1c5d2ba72d3d22df5597d123fdb60a9",
+        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
         "type": "github"
       },
       "original": {
@@ -177,11 +160,11 @@
     },
     "haskell-flake_2": {
       "locked": {
-        "lastModified": 1741528687,
-        "narHash": "sha256-NPxvw+FaxMPgwGGGiTbmNpfjFhR1HwPRWTBJJufWQ6Q=",
+        "lastModified": 1756071733,
+        "narHash": "sha256-hRlG8+m5oOBb6/a8DQAzrt0ApLYkbNfActj7b3OzeLk=",
         "owner": "srid",
         "repo": "haskell-flake",
-        "rev": "f66fe097c01b4ac20a28b4f26e760dffd5891967",
+        "rev": "99200161a88c1cb83bb114ab237e66d3fe327692",
         "type": "github"
       },
       "original": {
@@ -238,11 +221,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1740877520,
-        "narHash": "sha256-oiwv/ZK/2FhGxrCkQkB83i7GnWXPPLzoqFHpDD3uYpk=",
+        "lastModified": 1753579242,
+        "narHash": "sha256-zvaMGVn14/Zz8hnp4VWT9xVnhc8vuL3TStRqwk22biA=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "147dee35aab2193b174e4c0868bd80ead5ce755c",
+        "rev": "0f36c44e01a6129be94e3ade315a5883f0228a6e",
         "type": "github"
       },
       "original": {
@@ -265,11 +248,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1741865919,
-        "narHash": "sha256-4thdbnP6dlbdq+qZWTsm4ffAwoS8Tiq1YResB+RP6WE=",
+        "lastModified": 1756438964,
+        "narHash": "sha256-yo473URkISSmBZeIE1o6Mf94VRSn5qFVFS9phb7l6eg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "573c650e8a14b2faa0041645ab18aed7e60f0c9a",
+        "rev": "c73522789a3c7552b1122773d6eaa34e1491cc1c",
         "type": "github"
       },
       "original": {
@@ -281,11 +264,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1730768919,
-        "narHash": "sha256-8AKquNnnSaJRXZxc5YmF/WfmxiHX6MMZZasRP6RRQkE=",
+        "lastModified": 1754340878,
+        "narHash": "sha256-lgmUyVQL9tSnvvIvBp7x1euhkkCho7n3TMzgjdvgPoU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a04d33c0c3f1a59a2c1cb0c6e34cd24500e5a1dc",
+        "rev": "cab778239e705082fe97bb4990e0d24c50924c04",
         "type": "github"
       },
       "original": {
@@ -302,11 +285,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1741379162,
-        "narHash": "sha256-srpAbmJapkaqGRE3ytf3bj4XshspVR5964OX5LfjDWc=",
+        "lastModified": 1755960406,
+        "narHash": "sha256-RF7j6C1TmSTK9tYWO6CdEMtg6XZaUKcvZwOCD2SICZs=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "b5a62751225b2f62ff3147d0a334055ebadcd5cc",
+        "rev": "e891a93b193fcaf2fc8012d890dc7f0befe86ec2",
         "type": "github"
       },
       "original": {
@@ -317,7 +300,6 @@
     },
     "root": {
       "inputs": {
-        "all-cabal-hashes": "all-cabal-hashes",
         "diagnose": "diagnose",
         "flake-parts": "flake-parts",
         "flake-root": "flake-root",

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,22 @@
 {
   "nodes": {
+    "all-cabal-hashes": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1741996796,
+        "narHash": "sha256-D2WZas9LgnUK/JcTbYUvgukZuXFr/Qwe1yZxHlg7TVs=",
+        "owner": "commercialhaskell",
+        "repo": "all-cabal-hashes",
+        "rev": "efc8c04eaabd4b69b77e7f97ed48f65ea0abeb72",
+        "type": "github"
+      },
+      "original": {
+        "owner": "commercialhaskell",
+        "ref": "hackage",
+        "repo": "all-cabal-hashes",
+        "type": "github"
+      }
+    },
     "diagnose": {
       "flake": false,
       "locked": {
@@ -189,22 +206,6 @@
         "type": "github"
       }
     },
-    "hlint": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1729435405,
-        "narHash": "sha256-IqGhE9pAaK6CtVTPrsOpWvZMkvICng8pwv6KSGVAg9I=",
-        "owner": "ndmitchell",
-        "repo": "hlint",
-        "rev": "ad9a1f8485eb34d40a59cc0bd1457d03fbffd50d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ndmitchell",
-        "repo": "hlint",
-        "type": "github"
-      }
-    },
     "just-flake": {
       "locked": {
         "lastModified": 1713316411,
@@ -293,11 +294,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1731890469,
-        "narHash": "sha256-D1FNZ70NmQEwNxpSSdTXCSklBH1z2isPR84J6DQrJGs=",
+        "lastModified": 1741865919,
+        "narHash": "sha256-4thdbnP6dlbdq+qZWTsm4ffAwoS8Tiq1YResB+RP6WE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5083ec887760adfe12af64830a66807423a859a7",
+        "rev": "573c650e8a14b2faa0041645ab18aed7e60f0c9a",
         "type": "github"
       },
       "original": {
@@ -346,13 +347,13 @@
     },
     "root": {
       "inputs": {
+        "all-cabal-hashes": "all-cabal-hashes",
         "diagnose": "diagnose",
         "flake-parts": "flake-parts",
         "flake-root": "flake-root",
         "fourmolu": "fourmolu",
         "h2jvm": "h2jvm",
         "haskell-flake": "haskell-flake_2",
-        "hlint": "hlint",
         "just-flake": "just-flake",
         "nixpkgs": "nixpkgs_2",
         "pre-commit-hooks": "pre-commit-hooks",

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "all-cabal-hashes": {
       "flake": false,
       "locked": {
-        "lastModified": 1741996796,
-        "narHash": "sha256-D2WZas9LgnUK/JcTbYUvgukZuXFr/Qwe1yZxHlg7TVs=",
+        "lastModified": 1742051834,
+        "narHash": "sha256-nSc9aIuXr7WJ5eCgL0hiblPKIkZ5fvJ8cdyv4XJnajE=",
         "owner": "commercialhaskell",
         "repo": "all-cabal-hashes",
-        "rev": "efc8c04eaabd4b69b77e7f97ed48f65ea0abeb72",
+        "rev": "251d18a4dc0c2937e734bd0c9e0a6d182ba66070",
         "type": "github"
       },
       "original": {
@@ -54,11 +54,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1730504689,
-        "narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
+        "lastModified": 1741352980,
+        "narHash": "sha256-+u2UunDA4Cl5Fci3m7S643HzKmIDAe+fiXrLqYsR2fs=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "506278e768c2a08bec68eb62932193e341f55c90",
+        "rev": "f4330d22f1c5d2ba72d3d22df5597d123fdb60a9",
         "type": "github"
       },
       "original": {
@@ -112,22 +112,6 @@
       "original": {
         "owner": "srid",
         "repo": "flake-root",
-        "type": "github"
-      }
-    },
-    "fourmolu": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1730733209,
-        "narHash": "sha256-J1PpAbRT6OWg1zlLr/edxwhU6wkQZ4j7QXWdU02oEMI=",
-        "owner": "fourmolu",
-        "repo": "fourmolu",
-        "rev": "78056311a86c9f5484b2613259df0348e094634d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "fourmolu",
-        "repo": "fourmolu",
         "type": "github"
       }
     },
@@ -193,11 +177,11 @@
     },
     "haskell-flake_2": {
       "locked": {
-        "lastModified": 1731869727,
-        "narHash": "sha256-pGoMqkV9CyYgMMOeDZEgeEfrZiwrwy+bc28mGoUuz2M=",
+        "lastModified": 1741528687,
+        "narHash": "sha256-NPxvw+FaxMPgwGGGiTbmNpfjFhR1HwPRWTBJJufWQ6Q=",
         "owner": "srid",
         "repo": "haskell-flake",
-        "rev": "c984756f8dd2146be274b4845f2cc211c9bbb0e3",
+        "rev": "f66fe097c01b4ac20a28b4f26e760dffd5891967",
         "type": "github"
       },
       "original": {
@@ -254,14 +238,17 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1730504152,
-        "narHash": "sha256-lXvH/vOfb4aGYyvFmZK/HlsNsr/0CVWlwYvo2rxJk3s=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
+        "lastModified": 1740877520,
+        "narHash": "sha256-oiwv/ZK/2FhGxrCkQkB83i7GnWXPPLzoqFHpDD3uYpk=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "147dee35aab2193b174e4c0868bd80ead5ce755c",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
       }
     },
     "nixpkgs-lib_2": {
@@ -274,22 +261,6 @@
       "original": {
         "type": "tarball",
         "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
-      }
-    },
-    "nixpkgs-stable": {
-      "locked": {
-        "lastModified": 1730741070,
-        "narHash": "sha256-edm8WG19kWozJ/GqyYx2VjW99EdhjKwbY3ZwdlPAAlo=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d063c1dd113c91ab27959ba540c0d9753409edf3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-24.05",
-        "repo": "nixpkgs",
-        "type": "github"
       }
     },
     "nixpkgs_2": {
@@ -328,15 +299,14 @@
       "inputs": {
         "flake-compat": "flake-compat",
         "gitignore": "gitignore",
-        "nixpkgs": "nixpkgs_3",
-        "nixpkgs-stable": "nixpkgs-stable"
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1732021966,
-        "narHash": "sha256-mnTbjpdqF0luOkou8ZFi2asa1N3AA2CchR/RqCNmsGE=",
+        "lastModified": 1741379162,
+        "narHash": "sha256-srpAbmJapkaqGRE3ytf3bj4XshspVR5964OX5LfjDWc=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "3308484d1a443fc5bc92012435d79e80458fe43c",
+        "rev": "b5a62751225b2f62ff3147d0a334055ebadcd5cc",
         "type": "github"
       },
       "original": {
@@ -351,7 +321,6 @@
         "diagnose": "diagnose",
         "flake-parts": "flake-parts",
         "flake-root": "flake-root",
-        "fourmolu": "fourmolu",
         "h2jvm": "h2jvm",
         "haskell-flake": "haskell-flake_2",
         "just-flake": "just-flake",

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
     diagnose.flake = false;
 
     all-cabal-hashes.url = "github:commercialhaskell/all-cabal-hashes/hackage";
-all-cabal-hashes.flake = false;
+    all-cabal-hashes.flake = false;
   };
 
   outputs = inputs@{ self, pre-commit-hooks, nixpkgs, ... }:
@@ -42,34 +42,30 @@ all-cabal-hashes.flake = false;
           packages = {
             h2jvm.source = inputs.h2jvm;
             diagnose.source = inputs.diagnose;
-            # megaparsec.source = inputs.megaparsec;
-            polysemy-test.source = "0.10.0.0";
+
             fourmolu.source = "0.18.0.0";
             hlint.source = "3.10";
             ghc-lib-parser.source = "9.12.1.20250314";
             ghc-lib-parser-ex.source = "9.12.0.0";
-ormolu.source = "0.8.0.0";
-Cabal-syntax.source = "3.14.1.0";
+            ormolu.source = "0.8.0.0";
+            Cabal-syntax.source = "3.14.1.0";
+
+            polysemy-test.source = "0.10.0.1";
+
+            polysemy-time.source = "0.7.0.1";
+            polysemy-resume.source = "0.9.0.1";
+            polysemy-conc.source = "0.14.1.1";
           };
 
           settings = {
             ghc-lib-parser.buildFromSdist = true;
             fourmolu.check = false;
             fourmolu.jailbreak = true;
-            polysemy-test.jailbreak = true;
-            polysemy-conc.jailbreak = true;
-            polysemy-conc.check = false;
             polysemy-log.jailbreak = true;
-            polysemy-plugin.jailbreak = true;
             incipit-base.jailbreak = true;
             incipit-core.jailbreak = true;
-            polysemy-resume.jailbreak = true;
-            polysemy-time.jailbreak = true;
 
             diagnose = {
-              extraBuildDepends = [
-                # pkgs.haskellPackages
-              ];
               cabalFlags.megaparsec-compat = true;
               jailbreak = true;
             };
@@ -91,14 +87,9 @@ Cabal-syntax.source = "3.14.1.0";
 
             crypton-x509 = { check = false; };
 
-# haskell-language-server.cabalFlags = { ormolu = false;};
           };
 
           devShell = {
-            tools = hp: {
-              # treefmt = config.treefmt.build.wrapper;
-            };
-
             hlsCheck.enable = false;
           };
         };
@@ -117,7 +108,6 @@ Cabal-syntax.source = "3.14.1.0";
         just-flake.features = {
           treefmt.enable = true;
         };
-
 
 
 

--- a/flake.nix
+++ b/flake.nix
@@ -13,9 +13,6 @@
     diagnose.url = "github:bristermitten/diagnose";
     diagnose.flake = false;
 
-    fourmolu.url = "github:fourmolu/fourmolu";
-    fourmolu.flake = false;
-
     all-cabal-hashes.url = "github:commercialhaskell/all-cabal-hashes/hackage";
 all-cabal-hashes.flake = false;
   };
@@ -38,11 +35,7 @@ all-cabal-hashes.flake = false;
           autoWire = [ "packages" "apps" "checks" ]; # Wire all but the devShell
 
           basePackages = pkgs.haskell.packages.ghc910.override {
-            all-cabal-hashes = inputs.all-cabal-hashes;
-            overrides =  (self: super: {
-              # hlint = self.hlint_3_8;
-              # ghc-lib-parser = self.ghc-lib-parser_9_12_1_20241218;
-            });
+            all-cabal-hashes = inputs.all-cabal-hashes; # we need this so that the later x.source = y sections work
           };
 
 

--- a/flake.nix
+++ b/flake.nix
@@ -13,8 +13,8 @@
     diagnose.url = "github:bristermitten/diagnose";
     diagnose.flake = false;
 
-    all-cabal-hashes.url = "github:commercialhaskell/all-cabal-hashes/hackage";
-    all-cabal-hashes.flake = false;
+    # all-cabal-hashes.url = "github:commercialhaskell/all-cabal-hashes/hackage";
+    # all-cabal-hashes.flake = false;
   };
 
   outputs = inputs@{ self, pre-commit-hooks, nixpkgs, ... }:
@@ -34,36 +34,25 @@
 
           autoWire = [ "packages" "apps" "checks" ]; # Wire all but the devShell
 
-          basePackages = pkgs.haskell.packages.ghc910.override {
-            all-cabal-hashes = inputs.all-cabal-hashes; # we need this so that the later x.source = y sections work
-          };
+          basePackages = pkgs.haskell.packages.ghc912;
 
 
           packages = {
             h2jvm.source = inputs.h2jvm;
             diagnose.source = inputs.diagnose;
+            ghc-tcplugins-extra.source = "0.5";
 
-            fourmolu.source = "0.18.0.0";
-            hlint.source = "3.10";
-            ghc-lib-parser.source = "9.12.1.20250314";
-            ghc-lib-parser-ex.source = "9.12.0.0";
-            ormolu.source = "0.8.0.0";
-            Cabal-syntax.source = "3.14.1.0";
-
-            polysemy-test.source = "0.10.0.1";
-
-            polysemy-time.source = "0.7.0.1";
-            polysemy-resume.source = "0.9.0.1";
-            polysemy-conc.source = "0.14.1.1";
           };
 
           settings = {
-            ghc-lib-parser.buildFromSdist = true;
-            fourmolu.check = false;
-            fourmolu.jailbreak = true;
+
             polysemy-log.jailbreak = true;
             incipit-base.jailbreak = true;
             incipit-core.jailbreak = true;
+            polysemy-test.jailbreak = true;
+            polysemy-time.jailbreak = true;
+            polysemy-resume.jailbreak = true;
+            polysemy-conc.jailbreak = true;
 
             diagnose = {
               cabalFlags.megaparsec-compat = true;
@@ -81,11 +70,10 @@
               check = false;
             };
 
-            ghcid = {
-              separateBinOutput = false;
-            };
 
-            crypton-x509 = { check = false; };
+
+            optics.check = false;
+            generic-optics.check = false;
 
           };
 

--- a/flake.nix
+++ b/flake.nix
@@ -13,11 +13,11 @@
     diagnose.url = "github:bristermitten/diagnose";
     diagnose.flake = false;
 
-    hlint.url = "github:ndmitchell/hlint";
-    hlint.flake = false;
-
     fourmolu.url = "github:fourmolu/fourmolu";
     fourmolu.flake = false;
+
+    all-cabal-hashes.url = "github:commercialhaskell/all-cabal-hashes/hackage";
+all-cabal-hashes.flake = false;
   };
 
   outputs = inputs@{ self, pre-commit-hooks, nixpkgs, ... }:
@@ -37,7 +37,13 @@
 
           autoWire = [ "packages" "apps" "checks" ]; # Wire all but the devShell
 
-          basePackages = pkgs.haskell.packages.ghc910;
+          basePackages = pkgs.haskell.packages.ghc910.override {
+            all-cabal-hashes = inputs.all-cabal-hashes;
+            overrides =  (self: super: {
+              # hlint = self.hlint_3_8;
+              # ghc-lib-parser = self.ghc-lib-parser_9_12_1_20241218;
+            });
+          };
 
 
           packages = {
@@ -45,13 +51,18 @@
             diagnose.source = inputs.diagnose;
             # megaparsec.source = inputs.megaparsec;
             polysemy-test.source = "0.10.0.0";
-            hlint.source = inputs.hlint;
-            fourmolu.source = inputs.fourmolu;
+            fourmolu.source = "0.18.0.0";
+            hlint.source = "3.10";
+            ghc-lib-parser.source = "9.12.1.20250314";
+            ghc-lib-parser-ex.source = "9.12.0.0";
+ormolu.source = "0.8.0.0";
+Cabal-syntax.source = "3.14.1.0";
           };
 
           settings = {
-            hlint.jailbreak = true;
+            ghc-lib-parser.buildFromSdist = true;
             fourmolu.check = false;
+            fourmolu.jailbreak = true;
             polysemy-test.jailbreak = true;
             polysemy-conc.jailbreak = true;
             polysemy-conc.check = false;
@@ -86,6 +97,8 @@
             };
 
             crypton-x509 = { check = false; };
+
+# haskell-language-server.cabalFlags = { ormolu = false;};
           };
 
           devShell = {

--- a/package.yaml
+++ b/package.yaml
@@ -23,6 +23,7 @@ dependencies:
   - optics >= 0.4.1
   - generic-optics
   - containers
+  - matrix
   - bytestring
   - utf8-string
   - array

--- a/source.elr
+++ b/source.elr
@@ -5,3 +5,5 @@ import Elara.Prim
 let bbb = let loop x = if x == 0 then x else loop (x - 1) in loop
 
 let id = let i = \x -> x in i i
+
+let main = println (bbb 1)

--- a/source.elr
+++ b/source.elr
@@ -4,4 +4,5 @@ import Elara.Prim
 import List
 
 let add1 = \x -> x - 1
-let main = println (map add1 [1, 2, 3])
+
+let main = println (map add1 [1, 2, 3]) >>= (\_ -> println "hi")

--- a/source.elr
+++ b/source.elr
@@ -1,9 +1,7 @@
 import Prelude
 import Option
 import Elara.Prim
+import List
 
-let bbb = let loop x = if x == 0 then x else loop (x - 1) in loop
-
-let id = let i = \x -> x in i i
-
-let main = println (bbb 1)
+let add1 = \x -> x - 1
+let main = println (map add1 [1, 2, 3])

--- a/source.elr
+++ b/source.elr
@@ -3,6 +3,9 @@ import Option
 import Elara.Prim
 import List
 
-let add1 = \x -> x - 1
+type Pair a b = Pair a b
 
-let main = println (map add1 [1, 2, 3]) >>= (\_ -> println "hi")
+
+let nextTo = \x -> Pair (x + 1) (x - 1)
+
+let main = println (map nextTo [1, 2, 3]) *> ( println "hi")

--- a/source.elr
+++ b/source.elr
@@ -2,10 +2,8 @@ import Prelude
 import Option
 import Elara.Prim
 import List
+import Tuple
 
-type Pair a b = Pair a b
 
 
-let nextTo = \x -> Pair (x + 1) (x - 1)
-
-let main = println (map nextTo [1, 2, 3]) *> ( println "hi")
+let main = (println (listToString (zip [1, 2, 3] [4,5,6])))

--- a/src/Elara/AST/Generic/Instances/Pretty.hs
+++ b/src/Elara/AST/Generic/Instances/Pretty.hs
@@ -82,11 +82,12 @@ instance
         -- The converting of values to a 'Maybe' is handled by the 'ToMaybe' class.
         prettyDB (Value n e@(Expr (_, t)) _ t' ann) =
             let typeOfE =
+                    -- Prioritise the type in the declaration (as this is either a type the user explicitly wrote, or a generalised version)
                     ( UnknownPretty
-                        <$> (toMaybe t :: Maybe exprType) -- Prioritise the type in the expression
+                        <$> (toMaybe t' :: Maybe valueType)
                     )
                         <|> ( UnknownPretty
-                                <$> (toMaybe t' :: Maybe valueType) -- Otherwise, use the type in the declaration
+                                <$> (toMaybe t :: Maybe exprType) -- If it's not in the declaration, use the type of the expression
                             )
              in prettyValueDeclaration n e typeOfE ann
         prettyDB (TypeDeclaration n vars t ann) = prettyTypeDeclaration n vars t ann

--- a/src/Elara/AST/Generic/Types.hs
+++ b/src/Elara/AST/Generic/Types.hs
@@ -253,7 +253,13 @@ data TypeDeclAnnotations ast = TypeDeclAnnotations
     }
 
 data TypeDeclaration ast
-    = ADT (NonEmpty (ASTLocate ast (Select "ConstructorName" ast), [Select "ADTParam" ast]))
+    = ADT
+        ( NonEmpty
+            -- Non-empty list of constructors
+            ( ASTLocate ast (Select "ConstructorName" ast) -- Constructor name
+            , [Select "ADTParam" ast] -- Constructor parameters
+            )
+        )
     | Alias !(Select "Alias" ast)
     deriving (Generic)
 

--- a/src/Elara/AST/Renamed.hs
+++ b/src/Elara/AST/Renamed.hs
@@ -79,7 +79,7 @@ newtype RenamedTypeDeclAnnotations = RenamedTypeDeclAnnotations
 -- Selections for 'Declaration'
 type instance Select "DeclarationName" Renamed = Qualified Name
 type instance Select "AnyName" Renamed = Name
-type instance Select "TypeName" Renamed = TypeName
+type instance Select "TypeName" Renamed = Qualified TypeName
 type instance Select "ValueName" Renamed = Qualified VarName
 
 -- Selections for 'Type'

--- a/src/Elara/AST/Shunted.hs
+++ b/src/Elara/AST/Shunted.hs
@@ -74,7 +74,7 @@ type instance Select "ADTParam" 'Shunted = ShuntedType
 -- Selections for 'Declaration'
 type instance Select "DeclarationName" 'Shunted = Qualified Name
 type instance Select "AnyName" Shunted = Name
-type instance Select "TypeName" Shunted = TypeName
+type instance Select "TypeName" Shunted = Qualified TypeName
 type instance Select "ValueName" Shunted = Qualified VarName
 
 -- Selections for 'Type'

--- a/src/Elara/AST/Typed.hs
+++ b/src/Elara/AST/Typed.hs
@@ -35,7 +35,8 @@ type instance Select "LambdaPattern" 'Typed = TypedLambdaParam (Unique VarName) 
 
 type instance Select "LetPattern" 'Typed = NoFieldValue
 
-type instance Select "VarRef" 'Typed = VarRef VarName
+-- VarRefs may have polytypes
+type instance Select "VarRef" 'Typed = (VarRef VarName, Type SourceRegion)
 
 type instance Select "ConRef" 'Typed = Qualified TypeName
 
@@ -63,7 +64,7 @@ type instance Select "TypeApplication" Typed = Monotype SourceRegion
 -- Selections for 'DeclarationBody'
 type instance Select "ValuePatterns" 'Typed = NoFieldValue
 
-type instance Select "ValueType" 'Typed = NoFieldValue -- types are kept in the expression rather than declarations now
+type instance Select "ValueType" 'Typed = Type SourceRegion
 
 type instance Select "ValueTypeDef" 'Typed = DataConCantHappen
 type instance Select "InfixDecl" 'Typed = DataConCantHappen
@@ -121,9 +122,10 @@ instance HasDependencies TypedDeclaration where
                     toList (NTypeName <<$>> (ctors ^.. each % _1 % unlocated))
                 _ -> []
     dependencies decl = case decl ^. _Unwrapped % unlocated % field' @"body" % _Unwrapped % unlocated of
-        Generic.Value _ e NoFieldValue NoFieldValue _ ->
+        Generic.Value _ e NoFieldValue type' _ ->
             valueDependencies e
                 <> patternDependencies e
+                <> typeDependencies type'
         Generic.TypeDeclaration _ _ x _ ->
             case x of
                 Located _ (Generic.ADT ctors) ->
@@ -134,10 +136,10 @@ instance HasDependencies TypedDeclaration where
 valueDependencies :: TypedExpr -> [Qualified Name]
 valueDependencies x =
     concatMapOf (cosmosOn (_Unwrapped % _1 % unlocated)) names x
-        <> concatMapOf (cosmosOnOf (_Unwrapped % _2) gplate) typeDependencies x
+        <> concatMapOf (cosmosOnOf (_Unwrapped % _2) gplate) monotypeDependencies x
   where
     names :: TypedExpr' -> [Qualified Name]
-    names (Generic.Var (Located _ (Global e))) = NVarName <<$>> [e ^. unlocated]
+    names (Generic.Var (Located _ (Global e, t))) = (NVarName <<$>> [e ^. unlocated]) <> typeDependencies t
     names (Generic.Constructor (Located _ e)) = [NTypeName <$> e]
     names _ = []
 
@@ -151,5 +153,8 @@ patternDependencies =
     names (Generic.ConstructorPattern (Located _ e) _) = [NTypeName <$> e]
     names _ = []
 
-typeDependencies :: Monotype SourceRegion -> [Qualified Name]
+monotypeDependencies :: Monotype SourceRegion -> [Qualified Name]
+monotypeDependencies t = t ^.. gplate @(Qualified TypeName) % to (NTypeName <$>)
+
+typeDependencies :: Type SourceRegion -> [Qualified Name]
 typeDependencies t = t ^.. gplate @(Qualified TypeName) % to (NTypeName <$>)

--- a/src/Elara/AST/Typed.hs
+++ b/src/Elara/AST/Typed.hs
@@ -21,6 +21,7 @@ import Elara.Data.Kind (ElaraKind)
 import Elara.Data.TopologicalGraph
 import Elara.Data.Unique (Unique)
 import Elara.TypeInfer.Type (Monotype, Type (..))
+import Elara.TypeInfer.Unique
 
 type instance ASTLocate' 'Typed = Located
 
@@ -66,16 +67,16 @@ type instance Select "ValueType" 'Typed = NoFieldValue -- types are kept in the 
 type instance Select "ValueTypeDef" 'Typed = DataConCantHappen
 type instance Select "InfixDecl" 'Typed = DataConCantHappen
 type instance Select "Alias" 'Typed = (Type SourceRegion, ElaraKind)
-type instance Select "ADTParam" 'Typed = (Type SourceRegion, ElaraKind)
+type instance Select "ADTParam" 'Typed = (Monotype SourceRegion, ElaraKind)
 
 -- Selections for 'Declaration'
 type instance Select "DeclarationName" 'Typed = Qualified Name
 type instance Select "AnyName" Typed = Name
-type instance Select "TypeName" Typed = TypeName
+type instance Select "TypeName" Typed = Qualified TypeName
 type instance Select "ValueName" Typed = Qualified VarName
 
 -- Selections for 'Type'
-type instance Select "TypeVar" 'Typed = Unique LowerAlphaName
+type instance Select "TypeVar" 'Typed = UniqueTyVar
 type instance Select "TypeKind" 'Typed = ElaraKind
 type instance Select "KindAnnotation" 'Typed = ElaraKind
 

--- a/src/Elara/AST/VarRef.hs
+++ b/src/Elara/AST/VarRef.hs
@@ -31,6 +31,14 @@ pattern Local' n = Local (Identity n)
 
 {-# COMPLETE Global', Local' #-}
 
+pattern UnlocatedGlobal :: Qualified n -> UnlocatedVarRef n
+pattern UnlocatedGlobal n = Global (Identity n)
+
+pattern UnlocatedLocal :: Unique n -> UnlocatedVarRef n
+pattern UnlocatedLocal n = Local (Identity n)
+
+{-# COMPLETE UnlocatedGlobal, UnlocatedLocal #-}
+
 varRefVal :: Functor c => VarRef' c n -> c n
 varRefVal (Global n) = fmap (view name) n
 varRefVal (Local n) = fmap (view uniqueVal) n
@@ -48,24 +56,6 @@ varRefVal' = traversalVL $ \f ->
 ignoreLocation :: VarRef n -> IgnoreLocVarRef n
 ignoreLocation (Global n) = Global (IgnoreLocation n)
 ignoreLocation (Local n) = Local (IgnoreLocation n)
-
-mkLocal :: ToName n => Located (Unique n) -> VarRef Name
-mkLocal n = Local (toName <<$>> n)
-
-mkLocal' :: ToName n => Located (Unique n) -> IgnoreLocVarRef Name
-mkLocal' n = Local (toName <<$>> IgnoreLocation n)
-
-mkGlobal :: ToName n => Located (Qualified n) -> VarRef Name
-mkGlobal n = Global (toName <<$>> n)
-
-mkGlobal' :: ToName n => Located (Qualified n) -> IgnoreLocVarRef Name
-mkGlobal' n = Global (toName <<$>> IgnoreLocation n)
-
-mkGlobalUnlocated :: ToName n => Qualified n -> UnlocatedVarRef Name
-mkGlobalUnlocated n = Global (Identity (toName <$> n))
-
-mkLocalUnlocated :: ToName n => Unique n -> UnlocatedVarRef Name
-mkLocalUnlocated n = Local (Identity (toName <$> n))
 
 withName :: ToName n => VarRef n -> VarRef Name
 withName (Global n) = Global (toName <<$>> n)

--- a/src/Elara/Core.hs
+++ b/src/Elara/Core.hs
@@ -70,17 +70,21 @@ data DataCon = DataCon
     , dataConType :: Type
     -- ^ The type of the data constructor, i.e. `type Foo a = Bar a` would have a data constructor with type `a -> Foo a`
     , dataConDataType :: TyCon
-    -- ^ The type of the data type the data constructor belongs to, i.e. `type Foo a = Bar a` would have a data constructor with type `Foo a`. This should be identical to @functionTypeResult . dataConType@
+    -- ^ The type of the data type the data constructor belongs to, i.e. `type Foo a = Bar a` would have a DataCon for `Bar a` with @dataConDataType = Foo a@. This should be identical to @functionTypeResult . dataConType@
     }
     deriving (Show, Eq, Data, Generic, Ord)
 
 data Type
-    = TyVarTy TypeVariable
-    | FuncTy Type Type
-    | AppTy Type Type
-    | -- | A type constructor
+    = -- | A type variable, @a@
+      TyVarTy TypeVariable
+    | -- | A function type, @t -> t'@
+      FuncTy Type Type
+    | -- | An application of a type constructor, @TC t@
+      AppTy Type Type
+    | -- | A type constructor, @TC@
       ConTy TyCon
-    | ForAllTy !TypeVariable !Type
+    | -- | A forall quantified type, @forall a. T@
+      ForAllTy !TypeVariable !Type
     deriving (Show, Eq, Data, Ord, Generic)
 
 data TyCon

--- a/src/Elara/Core/ANF.hs
+++ b/src/Elara/Core/ANF.hs
@@ -29,5 +29,6 @@ data Expr b
     deriving (Show, Eq, Data, Typeable, Generic)
 
 type Bind b = G.Bind b CExpr
+type TopLevelBind b = G.Bind b Expr
 
 type Alt b = (AltCon, [b], Expr b)

--- a/src/Elara/Core/Analysis.hs
+++ b/src/Elara/Core/Analysis.hs
@@ -94,3 +94,10 @@ instance FreeCoreVars ANF.Expr where
 freeCoreVarsBind :: (FreeCoreVars ast, Ord a) => Bind a ast -> Set a
 freeCoreVarsBind (NonRecursive (_, e)) = freeCoreVars e
 freeCoreVarsBind (Recursive bs) = foldMap (freeCoreVars . snd) bs
+
+freeTypeVars :: Core.Type -> Set Core.TypeVariable
+freeTypeVars (Core.TyVarTy tv) = one tv
+freeTypeVars (Core.ConTy _) = Set.empty
+freeTypeVars (Core.FuncTy a b) = freeTypeVars a <> freeTypeVars b
+freeTypeVars (Core.ForAllTy tv t) = Set.delete tv (freeTypeVars t)
+freeTypeVars (Core.AppTy a b) = freeTypeVars a <> freeTypeVars b

--- a/src/Elara/Core/Analysis.hs
+++ b/src/Elara/Core/Analysis.hs
@@ -49,7 +49,7 @@ guesstimateExprType = TraceableFn $ \self v ->
         (TyApp f t) ->
             self f <&> \case
                 Core.ForAllTy tv t' -> Core.substTypeVar tv t t'
-                t' -> error $ "exprType: expected forall type, got " <> show t' <> " in " <> show (TyApp f t)
+                t' -> error $ "exprType: expected forall type, got " <> showPretty t' <> " in " <> showPretty (TyApp f t)
         (Lam b e) -> Core.FuncTy (varType b) <$> (self e)
         (TyLam _ e) -> self e
         (Let _ e) -> self e

--- a/src/Elara/Core/Analysis.hs
+++ b/src/Elara/Core/Analysis.hs
@@ -32,22 +32,22 @@ findTyCon (Core.ForAllTy _ t) = findTyCon t
 findTyCon (Core.AppTy t _) = findTyCon t
 findTyCon _ = Nothing
 
-exprType :: (HasCallStack, Pretty Core.Type, Pretty (Expr Var)) => CoreExpr -> Core.Type
-exprType (Var v) = varType v
-exprType (Lit l) = literalType l
-exprType app@(App f _) = case exprType f of
+guesstimateExprType :: (HasCallStack, Pretty Core.Type, Pretty (Expr Var)) => CoreExpr -> Core.Type
+guesstimateExprType (Var v) = varType v
+guesstimateExprType (Lit l) = literalType l
+guesstimateExprType app@(App f _) = case guesstimateExprType f of
     Core.FuncTy _ t -> t
     Core.ForAllTy _ t -> t
     t -> error $ "exprType: expected function type, got " <> showPretty t <> " in " <> showPretty app
-exprType (TyApp f t) = case exprType f of
+guesstimateExprType (TyApp f t) = case guesstimateExprType f of
     Core.ForAllTy tv t' -> Core.substTypeVar tv t t'
     t' -> error $ "exprType: expected forall type, got " <> show t' <> " in " <> show (TyApp f t)
-exprType (Lam b e) = Core.FuncTy (varType b) (exprType e)
-exprType (TyLam _ e) = exprType e
-exprType (Let _ e) = exprType e
-exprType (Match _ _ alts) = case alts of
+guesstimateExprType (Lam b e) = Core.FuncTy (varType b) (guesstimateExprType e)
+guesstimateExprType (TyLam _ e) = guesstimateExprType e
+guesstimateExprType (Let _ e) = guesstimateExprType e
+guesstimateExprType (Match _ _ alts) = case alts of
     [] -> error "exprType: empty match"
-    (_, _, e) : _ -> exprType e
+    (_, _, e) : _ -> guesstimateExprType e
 
 varType :: Var -> Core.Type
 varType (TyVar tv) = Core.TyVarTy tv

--- a/src/Elara/Core/Analysis.hs
+++ b/src/Elara/Core/Analysis.hs
@@ -8,6 +8,7 @@ import Data.Set qualified as Set
 import Elara.Core.ANF qualified as ANF
 import Elara.Core.Generic (Bind (..), binders)
 import Elara.Data.Pretty
+import Elara.Logging (TraceableFn)
 import Elara.Prim.Core (charCon, doubleCon, intCon, stringCon, unitCon)
 import Print (showPretty)
 
@@ -32,22 +33,24 @@ findTyCon (Core.ForAllTy _ t) = findTyCon t
 findTyCon (Core.AppTy t _) = findTyCon t
 findTyCon _ = Nothing
 
-guesstimateExprType :: (HasCallStack, Pretty Core.Type, Pretty (Expr Var)) => CoreExpr -> Core.Type
-guesstimateExprType (Var v) = varType v
-guesstimateExprType (Lit l) = literalType l
-guesstimateExprType app@(App f _) = case guesstimateExprType f of
-    Core.FuncTy _ t -> t
-    Core.ForAllTy _ t -> t
-    t -> error $ "exprType: expected function type, got " <> showPretty t <> " in " <> showPretty app
-guesstimateExprType (TyApp f t) = case guesstimateExprType f of
-    Core.ForAllTy tv t' -> Core.substTypeVar tv t t'
-    t' -> error $ "exprType: expected forall type, got " <> show t' <> " in " <> show (TyApp f t)
-guesstimateExprType (Lam b e) = Core.FuncTy (varType b) (guesstimateExprType e)
-guesstimateExprType (TyLam _ e) = guesstimateExprType e
-guesstimateExprType (Let _ e) = guesstimateExprType e
-guesstimateExprType (Match _ _ alts) = case alts of
+guesstimateExprType :: (HasCallStack, Pretty Core.Type, Pretty (Expr Var)) => TraceableFn "guesstimateExprType" CoreExpr Core.Type
+guesstimateExprType self (Var v) = pure $ varType v
+guesstimateExprType self (Lit l) = pure $ literalType l
+guesstimateExprType self app@(App f _) =
+    self f <&> \case
+        Core.FuncTy _ t -> t
+        Core.ForAllTy _ t -> t
+        t -> error $ "exprType: expected function type, got " <> showPretty t <> " in " <> showPretty app
+guesstimateExprType self (TyApp f t) =
+    self f <&> \case
+        Core.ForAllTy tv t' -> Core.substTypeVar tv t t'
+        t' -> error $ "exprType: expected forall type, got " <> show t' <> " in " <> show (TyApp f t)
+guesstimateExprType self (Lam b e) = Core.FuncTy (varType b) <$> (self e)
+guesstimateExprType self (TyLam _ e) = self e
+guesstimateExprType self (Let _ e) = self e
+guesstimateExprType self (Match _ _ alts) = case alts of
     [] -> error "exprType: empty match"
-    (_, _, e) : _ -> guesstimateExprType e
+    (_, _, e) : _ -> self e
 
 varType :: Var -> Core.Type
 varType (TyVar tv) = Core.TyVarTy tv

--- a/src/Elara/Core/LiftClosures.hs
+++ b/src/Elara/Core/LiftClosures.hs
@@ -11,7 +11,7 @@ import Elara.Core.Module (CoreDeclaration (..), CoreModule (..))
 import Elara.Core.ToANF (fromANF)
 import Elara.Data.Pretty
 import Elara.Data.Unique (UniqueGen, makeUnique)
-import Elara.Logging (StructuredDebug, debug)
+import Elara.Logging (StructuredDebug, debug, traceFn)
 import Polysemy
 import Polysemy.Writer (Writer, runWriter, tell)
 import Prelude hiding (Alt)
@@ -96,9 +96,11 @@ liftClosuresA' env (ANF.Lam v e) = do
             pure $ Lam v e'
         else do
             v' <- makeUnique "closure"
-            let lambdaType = case v of
-                    Core.Id _ t _ -> t `Core.FuncTy` guesstimateExprType (fromANF e)
-                    Core.TyVar _ -> error "liftClosuresA': TyVar"
+            lambdaType <- case v of
+                Core.Id _ t _ -> do
+                    guessedType <- traceFn guesstimateExprType (fromANF e)
+                    pure $ t `Core.FuncTy` guessedType
+                Core.TyVar _ -> error "liftClosuresA': TyVar"
             let id = Core.Id (Local' v') lambdaType Nothing
             tell [(id, ANF.AExpr $ Lam v e)]
             pure $ Var id

--- a/src/Elara/Core/LiftClosures.hs
+++ b/src/Elara/Core/LiftClosures.hs
@@ -97,7 +97,7 @@ liftClosuresA' env (ANF.Lam v e) = do
         else do
             v' <- makeUnique "closure"
             let lambdaType = case v of
-                    Core.Id _ t _ -> t `Core.FuncTy` exprType (fromANF e)
+                    Core.Id _ t _ -> t `Core.FuncTy` guesstimateExprType (fromANF e)
                     Core.TyVar _ -> error "liftClosuresA': TyVar"
             let id = Core.Id (Local' v') lambdaType Nothing
             tell [(id, ANF.AExpr $ Lam v e)]

--- a/src/Elara/Core/Module.hs
+++ b/src/Elara/Core/Module.hs
@@ -8,7 +8,7 @@ module Elara.Core.Module where
 import Data.Generics.Product
 import Elara.AST.Name (ModuleName, Qualified)
 import Elara.AST.Pretty (prettyBlockExpr)
-import Elara.Core (DataCon, Type, TypeVariable)
+import Elara.Core (CoreBind, DataCon, Type, TypeVariable)
 import Elara.Core.Pretty (prettyTy, prettyTypeVariables)
 import Elara.Data.Kind (ElaraKind)
 import Elara.Data.Pretty (AnsiStyle, Doc, Pretty (pretty), bracedBlock, hardline, indentDepth, nest, (<+>))
@@ -21,15 +21,18 @@ data CoreModule bind = CoreModule
     }
     deriving (Generic)
 
-instance HasDependencies (CoreModule bind) where
+-- the constraint is necessary for 'gplate' to be able to find the fields correctly
+instance bind ~ CoreBind => HasDependencies (CoreModule bind) where
     type Key (CoreModule bind) = ModuleName
     key = view (field @"name")
 
-    dependencies = const [] -- TODO
+    dependencies m = do
+        m ^.. field @"declarations" % (gplate @(Qualified Text)) % field @"qualifier"
 
 data CoreDeclaration bind
     = CoreValue bind
     | CoreType CoreTypeDecl
+    deriving (Generic)
 
 data CoreTypeDecl = CoreTypeDecl
     { ctdName :: !(Qualified Text)
@@ -37,10 +40,12 @@ data CoreTypeDecl = CoreTypeDecl
     , typeVars :: ![TypeVariable]
     , typeBody :: CoreTypeDeclBody
     }
+    deriving (Generic)
 
 data CoreTypeDeclBody
     = CoreTypeAlias Type
     | CoreDataDecl [DataCon]
+    deriving (Generic)
 
 instance Pretty bind => Pretty (CoreModule bind) where
     pretty (CoreModule name decls) =

--- a/src/Elara/Core/Pretty.hs
+++ b/src/Elara/Core/Pretty.hs
@@ -135,7 +135,7 @@ prettyAlt (con, vars, e) =
     pretty @AltCon con
         <> (if null vars then "" else space <> hsep (prettyVarArg <$> vars))
             <+> "->"
-            <+> line
+        <> line
         <> indent indentDepth (prettyExpr e)
 
 instance Pretty Literal where

--- a/src/Elara/Core/ToANF.hs
+++ b/src/Elara/Core/ToANF.hs
@@ -33,6 +33,7 @@ type ToANF r =
     , Pretty (ANF.AExpr Core.Var)
     , Pretty (ANF.CExpr Core.Var)
     , Pretty (ANF.Expr Core.Var)
+    , Pretty Core.Type
     )
 
 toANF :: ToANF r => Core.CoreExpr -> Sem r (ANF.Expr Core.Var)

--- a/src/Elara/Core/ToANF.hs
+++ b/src/Elara/Core/ToANF.hs
@@ -8,7 +8,7 @@ import Elara.Core.Analysis (guesstimateExprType)
 import Elara.Core.Generic (Bind (..))
 import Elara.Data.Pretty
 import Elara.Data.Unique
-import Elara.Logging (StructuredDebug, debug, debugWith)
+import Elara.Logging (StructuredDebug, debug, debugWith, traceFn)
 import Polysemy
 
 {- | Convert a Core expression to ANF
@@ -64,7 +64,8 @@ toANF' other k = debugWith ("toANF' " <> pretty other <> ":") $ evalContT $ do
     v <- lift $ makeUnique "var"
 
     lift $ toANFRec other $ \e -> do
-        let id = Core.Id (Local' v) (guesstimateExprType (fromANFCExpr e)) Nothing
+        exprType <- lift $ traceFn guesstimateExprType (fromANFCExpr e)
+        let id = Core.Id (Local' v) (exprType) Nothing
 
         l' <- lift $ k $ ANF.Var id
         lift $ debug $ "Creating let " <> pretty id <> " = " <> pretty e <> " in " <> pretty l'

--- a/src/Elara/CoreToCore.hs
+++ b/src/Elara/CoreToCore.hs
@@ -13,6 +13,7 @@ import Elara.Core.Generic (Bind (..), mapBind, traverseBind)
 import Elara.Core.Module (CoreDeclaration (..), CoreModule (..))
 import Elara.Core.ToANF
 import Polysemy hiding (transform)
+import qualified Elara.Core as Core
 
 type CoreExprPass = CoreExpr -> CoreExpr
 
@@ -68,8 +69,8 @@ fullCoreToCoreExpr = fix' coreToCoreExpr
 -- toANF :: CoreModule -> CoreModule
 toANF' ::
     ToANF r =>
-    CoreModule (Elara.Core.Generic.Bind Var Expr) ->
-    Sem r (CoreModule (Elara.Core.Generic.Bind Var ANF.Expr))
+    CoreModule (Elara.Core.Generic.Bind Var Core.Expr) ->
+    Sem r (CoreModule (ANF.TopLevelBind Var))
 toANF' (CoreModule name decls) = CoreModule name <$> traverse f decls
   where
     f (CoreValue v) = CoreValue <$> traverseBind pure toANF v

--- a/src/Elara/CoreToCore.hs
+++ b/src/Elara/CoreToCore.hs
@@ -75,6 +75,14 @@ toANF' (CoreModule name decls) = CoreModule name <$> traverse f decls
     f (CoreValue v) = CoreValue <$> traverseBind pure toANF v
     f (CoreType t) = pure (CoreType t)
 
+unANF ::
+    CoreModule (Elara.Core.Generic.Bind Var ANF.Expr) ->
+    CoreModule (Elara.Core.Generic.Bind Var Expr)
+unANF (CoreModule name decls) = CoreModule name (fmap f decls)
+  where
+    f (CoreValue v) = CoreValue (mapBind identity fromANF v)
+    f (CoreType t) = CoreType t
+
 coreToCore :: CoreModule CoreBind -> CoreModule CoreBind
 coreToCore (CoreModule name decls) = CoreModule name (fmap f decls)
   where

--- a/src/Elara/Data/Kind/Infer.hs
+++ b/src/Elara/Data/Kind/Infer.hs
@@ -66,13 +66,14 @@ initialInferState =
         }
 
 data KindInferError
-    = HasCallStack => UnknownKind (Qualified TypeName) (Map (Qualified TypeName) ElaraKind)
-    | HasCallStack => UnboundVar TypeVar (Map (Either (Qualified TypeName) TypeVar) KindVar)
+    = UnknownKind (Qualified TypeName) (Map (Qualified TypeName) ElaraKind)
+    | UnboundVar TypeVar (Map (Either (Qualified TypeName) TypeVar) KindVar)
     | CannotUnify ElaraKind ElaraKind
     | NotFunctionKind ElaraKind
     | OccursCheckFailed KindVar ElaraKind
+    deriving (Generic)
 
-deriving instance Show KindInferError
+instance Pretty KindInferError
 
 instance ReportableError KindInferError where
     report (UnknownKind name kinds) =
@@ -187,7 +188,9 @@ infer kindEnv decls = do
                 todo
         pure (kind, body')
 
-inferKind :: (Member (State InferState) r, Member (Error KindInferError) r, Member UniqueGen r) => Qualified TypeName -> [Located TypeVar] -> ShuntedTypeDeclaration -> Sem r (ElaraKind, KindedTypeDeclaration)
+inferKind ::
+    (Member (State InferState) r, Member (Error KindInferError) r, Member UniqueGen r) =>
+    Qualified TypeName -> [Located TypeVar] -> ShuntedTypeDeclaration -> Sem r (ElaraKind, KindedTypeDeclaration)
 inferKind name tvs t = do
     kindVar <- makeUniqueId
     declareNamedType name kindVar

--- a/src/Elara/Data/Pretty.hs
+++ b/src/Elara/Data/Pretty.hs
@@ -159,6 +159,9 @@ instance (Pretty a, Pretty b, Pretty c, Pretty d, Pretty e, Pretty f) => Pretty 
 instance {-# OVERLAPPABLE #-} PP.Pretty a => Pretty a where
     pretty = PP.pretty
 
+instance Pretty CallStack where
+    pretty = pretty . prettyCallStack
+
 escapeChar :: IsString s => Char -> s
 escapeChar c = case c of
     '\a' -> "\\a"

--- a/src/Elara/Data/Pretty.hs
+++ b/src/Elara/Data/Pretty.hs
@@ -9,6 +9,7 @@ module Elara.Data.Pretty (
     parensIf,
     blockParensIf,
     Pretty (..),
+    gpretty,
     module Pretty,
     module Prettyprinter.Render.Terminal,
     listToText,
@@ -102,7 +103,10 @@ bracedBlock b = do
 class Pretty a where
     pretty :: a -> Doc AnsiStyle
     default pretty :: (Generic a, GPretty (Rep a)) => a -> Doc AnsiStyle
-    pretty = sep . gprettyPrec 0 . from
+    pretty = gpretty
+
+gpretty :: (Generic a, GPretty (Rep a)) => a -> Doc AnsiStyle
+gpretty = sep . gprettyPrec 0 . from
 
 instance Pretty (Doc (Annotation AnsiStyle)) where
     pretty = pretty . reAnnotate defaultStyle

--- a/src/Elara/Data/Unique.hs
+++ b/src/Elara/Data/Unique.hs
@@ -40,11 +40,13 @@ instance ToJSON UniqueId
 instance Show UniqueId where
     show (UniqueId (Unique _ uniqueId)) = Text.Show.show uniqueId
 
-instance Eq (Unique a) where
-    (==) = (==) `on` view uniqueId
+instance Eq a => Eq (Unique a) where
+    (Unique a i) == (Unique b j) = i == j && a == b
 
-instance Ord (Unique a) where
-    compare = compare `on` view uniqueId
+instance Ord a => Ord (Unique a) where
+    compare (Unique a i) (Unique b j) = case compare i j of
+        EQ -> compare a b
+        other -> other
 
 newtype UniqueSupply = UniqueSupply
     { _uniqueSupplyUniques :: [Int]

--- a/src/Elara/Error.hs
+++ b/src/Elara/Error.hs
@@ -17,6 +17,7 @@ import Prelude hiding (asks, readFile)
 
 class ReportableError e where
     errorCode :: e -> Maybe ErrorCode
+    errorCode = const Nothing
     report :: Member (DiagnosticWriter (Doc AnsiStyle)) r => e -> Sem r ()
     default report :: Pretty e => Member (DiagnosticWriter (Doc AnsiStyle)) r => e -> Sem r ()
     report = defaultReport

--- a/src/Elara/Error.hs
+++ b/src/Elara/Error.hs
@@ -1,9 +1,13 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE ImpredicativeTypes #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
 
 module Elara.Error (ReportableError (..), defaultReport, addPosition, concatDiagnostics, module Elara.Error.Effect, runErrorOrReport, reportMaybe) where
 
 import Elara.Data.Pretty
+import Elara.Error.Codes
 import Elara.Error.Effect
 import Error.Diagnose
 import Polysemy
@@ -12,12 +16,20 @@ import Polysemy.Maybe (MaybeE, justE, nothingE)
 import Prelude hiding (asks, readFile)
 
 class ReportableError e where
+    errorCode :: e -> Maybe ErrorCode
     report :: Member (DiagnosticWriter (Doc AnsiStyle)) r => e -> Sem r ()
     default report :: Pretty e => Member (DiagnosticWriter (Doc AnsiStyle)) r => e -> Sem r ()
-    report e = defaultReport e
+    report = defaultReport
 
-defaultReport :: Pretty e => Member (DiagnosticWriter (Doc AnsiStyle)) r => e -> Sem r ()
-defaultReport e = writeReport (Err Nothing (pretty e) [] [])
+defaultReport ::
+    (ReportableError e, Pretty e) =>
+    Member (DiagnosticWriter (Doc AnsiStyle)) r =>
+    e -> Sem r ()
+defaultReport e =
+    {-# HLINT ignore "Use id" #-}
+    -- i love impredicative types
+    let code = (\x -> x) <$> errorCode e
+     in writeReport (Err code (pretty e) [] [])
 
 addPosition :: (Position, Marker msg) -> Report msg -> Report msg
 addPosition marker (Err code m markers notes) = Err code m (marker : markers) notes

--- a/src/Elara/Error/Codes.hs
+++ b/src/Elara/Error/Codes.hs
@@ -76,6 +76,13 @@ samePrecedence = "E2001"
 unknownPrecedence :: ErrorCode
 unknownPrecedence = "W2001"
 
+-- Type check errors
+unknownVariableTC :: ErrorCode
+unknownVariableTC = "E3001"
+
+coreTypeMismatch :: ErrorCode
+coreTypeMismatch = "E3002"
+
 invokeStaticLocal :: ErrorCode
 invokeStaticLocal = "E4001"
 

--- a/src/Elara/Interpreter.hs
+++ b/src/Elara/Interpreter.hs
@@ -88,7 +88,12 @@ instance Pretty (Sem InterpreterEffects a) where
 instance Pretty Value where
     pretty (Closure _ p _) = "Closure accepting" <+> pretty p
     pretty (RecClosure _ n p _) = "RecClosure" <+> pretty n <+> "accepting" <+> pretty p
-    pretty (Ctor c args) = pretty (c.name) <+> pretty args
+    pretty (Int i) = pretty i
+    pretty (String s) = pretty '"' <> pretty s <> pretty '"'
+    pretty (Char c) = pretty c
+    pretty (Double d) = pretty d
+    pretty (Ctor c []) = (pretty (c.name))
+    pretty (Ctor c args) = parens (pretty (c.name) <+> hsep (pretty <$> args))
     pretty p = gpretty p
 
 primOps =
@@ -144,7 +149,10 @@ interpretExpr (App f a) = debugWith ("Applying " <> pretty a <+> "to" <+> pretty
                 interpretExpr e
         PrimOp "println" -> do
             pure $ IOAction $ do
-                putStrLn (prettyToString a')
+                let asString = case a' of
+                        String s -> s
+                        other -> prettyToText other
+                putTextLn asString
                 pure (Ctor unitCtor [])
         PrimOp "negate" -> do
             case a' of

--- a/src/Elara/Interpreter.hs
+++ b/src/Elara/Interpreter.hs
@@ -1,6 +1,7 @@
 -- | Simple interpreter for the Core language
 module Elara.Interpreter where
 
+import Control.Concurrent (threadDelay)
 import Data.Map qualified as Map
 import Elara.AST.Name (ModuleName (..), Qualified (..), VarName)
 import Elara.AST.VarRef
@@ -8,17 +9,20 @@ import Elara.Core hiding (Literal (..))
 import Elara.Core qualified as Core
 import Elara.Core.Generic (Bind (..))
 import Elara.Core.Module
-import Elara.Pipeline
-import Elara.Prim.Core (unitCon)
-import Polysemy hiding (run)
-import Polysemy.State
 import Elara.Data.Pretty
 import Elara.Error (ReportableError, runErrorOrReport)
+import Elara.Logging (StructuredDebug, debug, debugWith, structuredDebugToLog)
+import Elara.Pipeline
+import Elara.Prim.Core (falseCtor, fetchPrimitiveName, trueCtor, unitCtor)
+import Polysemy hiding (run)
 import Polysemy.Error
+import Polysemy.State
+import Polysemy.State.Extra
+import Print (prettyToString)
 
 type Interpreter r = Members InterpreterEffects r
 
-type InterpreterEffects = [State ElaraState, Error InterpreterError, Embed IO]
+type InterpreterEffects = [State ElaraState, Error InterpreterError, StructuredDebug, Embed IO]
 
 data ElaraState = ElaraState
     { bindings :: Map (UnlocatedVarRef Text) Value
@@ -27,9 +31,16 @@ data ElaraState = ElaraState
 
 instance Pretty ElaraState
 
-data InterpreterError = 
-    UnboundVariable (UnlocatedVarRef Text)
+data InterpreterError
+    = UnboundVariable (UnlocatedVarRef Text) ElaraState
     | NotAClosure Value
+    | UnknownPrimitive Text
+    | UnhandledExpr CoreExpr
+    | NoMainFound ElaraState
+    | TypeMismatch
+        { expected :: Text
+        , actual :: Value
+        }
     deriving (Generic)
 
 instance Pretty InterpreterError
@@ -41,51 +52,180 @@ data Value
     | String Text
     | Char Char
     | Double Double
-    | Ctor TyCon [Value]
-    | Closure (ElaraState) CoreExpr
+    | Ctor DataCon [Value]
+    | Closure
+        { env :: Map (UnlocatedVarRef Text) Value -- Captured environment
+        , param :: UnlocatedVarRef Text -- Parameter name
+        , body :: CoreExpr -- Function body
+        }
+    | RecClosure
+        { recEnv :: Map (UnlocatedVarRef Text) Value
+        , name :: UnlocatedVarRef Text -- This function's name
+        , param :: UnlocatedVarRef Text -- Parameter
+        , body :: CoreExpr
+        }
+    | PrimOp Text
+    | PartialApplication Value Value
+    | IOAction (IO Value)
     deriving (Generic)
 
+instance Eq Value where
+    Int a == Int b = a == b
+    String a == String b = a == b
+    Char a == Char b = a == b
+    Double a == Double b = a == b
+    Ctor a b == Ctor c d = a == c && b == d
+    Closure{} == Closure{} = False
+    PrimOp a == PrimOp b = a == b
+    PartialApplication a b == PartialApplication c d = a == c && b == d
+    IOAction{} == IOAction{} = False
+    _ == _ = False
+
+-- bit of a hack
+instance Pretty (IO a) where
+    pretty _ = "<IO>"
+
 instance Pretty Value where
+    pretty (Closure _ p _) = "Closure accepting" <+> pretty p
+    pretty (RecClosure _ n p _) = "RecClosure" <+> pretty n <+> "accepting" <+> pretty p
+    pretty p = gpretty p
 
+primOps =
+    Map.fromList
+        [ ("==", 2)
+        , ("-", 2)
+        ]
 
-interpretExpr :: Interpreter r => CoreExpr -> Sem r Value
+boolValue :: Bool -> Value
+boolValue True = Ctor trueCtor []
+boolValue False = Ctor falseCtor []
+
+interpretExpr :: forall r. Interpreter r => CoreExpr -> Sem r Value
 interpretExpr (Lit (Core.Int i)) = pure $ Int i
 interpretExpr (Lit (Core.String s)) = pure $ String s
 interpretExpr (Lit (Core.Char c)) = pure $ Char c
 interpretExpr (Lit (Core.Double d)) = pure $ Double d
-interpretExpr (Lit Core.Unit) = pure $ Ctor unitCon []
+interpretExpr (Lit Core.Unit) = pure $ Ctor unitCtor []
+interpretExpr (App (Var (Id (UnlocatedGlobal primName) _ _)) (Lit (Core.String primArg))) | primName == fetchPrimitiveName = do
+    pure $ PrimOp primArg
 interpretExpr (Var (Id v _ _)) = do
     s <- get
     case Map.lookup v (bindings s) of
         Just val -> pure val
-        Nothing -> error $ "Unbound variable: " <> show v
+        Nothing -> throw $ UnboundVariable v s
+interpretExpr (Let bind in') = scoped $ do
+    interpretBinding bind
+    interpretExpr in'
+interpretExpr (Lam (Id v _ _) e) = do
+    s <- get
+    pure $ Closure (bindings s) v e
+interpretExpr (App f a) = debugWith ("Applying " <> pretty a <+> "to" <+> pretty f) $ do
+    f' <- interpretExpr f
+    debug $ pretty f <> " = " <> pretty f'
+    a' <- interpretExpr a
+    debug $ pretty a <> " = " <> pretty a'
+    case f' of
+        rec@(RecClosure env n p e) -> scoped $ do
+            -- add itself to the env
+            let env' = Map.insert n rec env
 
+            -- add the argument to the env
+            let env'' = Map.insert p a' env'
+
+            scoped $ do
+                modify (\s -> s{bindings = env''})
+                interpretExpr e
+        Closure env p e -> do
+            let env' = Map.insert p a' env
+            scoped $ do
+                modify (\s -> s{bindings = env'})
+                interpretExpr e
+        PrimOp "println" -> do
+            pure $ IOAction $ do
+                putStrLn (prettyToString a')
+                pure (Ctor unitCtor [])
+        PartialApplication (PrimOp "==") fst -> do
+            pure $ (boolValue (a' == fst))
+        PartialApplication (PrimOp "-") fst -> do
+            case (a', fst) of
+                (Int a, Int b) -> pure $ Int (a - b)
+                (Double a, Double b) -> pure $ Double (a - b)
+                _ -> throw TypeMismatch{expected = "Int or Double", actual = a'}
+        PrimOp primName -> do
+            case Map.lookup primName primOps of
+                Just 1 -> error "1-arg primop Should be handled here"
+                Just _ -> pure $ PartialApplication f' a'
+                Nothing -> throw $ UnknownPrimitive primName
+        other -> throw $ NotAClosure other
+interpretExpr (Match e of' alts) = debugWith ("Matching " <> pretty e) $ do
+    e' <- interpretExpr e
+    whenJust of' $ \(Id v _ _) -> do
+        modify (\s -> s{bindings = Map.insert v e' (bindings s)})
+
+    let go :: [Core.Alt Var] -> Sem r Value
+        go [] = throw $ UnhandledExpr e
+        go ((DataAlt c, vs, branchBody) : rest) = do
+            case e' of
+                Ctor c' args | c == c' -> do
+                    let vs' = (\(Id i _ _) -> i) <$> vs
+                    modify (\s -> s{bindings = foldr (uncurry Map.insert) (bindings s) (zip vs' args)})
+                    debug $ "Matched " <> pretty c <> ", so we eval " <> pretty branchBody
+                    interpretExpr branchBody
+                _ -> go rest
+        go ((LitAlt l, _, branchBody) : rest) = do
+            case e' of
+                Int i | l == Core.Int i -> interpretExpr branchBody
+                String s | l == Core.String s -> interpretExpr branchBody
+                Char c | l == Core.Char c -> interpretExpr branchBody
+                Double d | l == Core.Double d -> interpretExpr branchBody
+                _ -> go rest
+        go ((DEFAULT, _, branchBody) : _) = interpretExpr branchBody
+    go alts
+interpretExpr other = throw $ UnhandledExpr other
+
+interpretBinding :: Interpreter r => CoreBind -> Sem r ()
+interpretBinding (NonRecursive (Id v _ _, e)) = debugWith ("Interpreting let" <+> pretty v <+> "=" <+> pretty e) $ do
+    val <- interpretExpr e
+    modify (\s -> s{bindings = Map.insert v val (bindings s)})
+interpretBinding (Recursive bs) = debugWith ("Interpreting letrec" <+> pretty bs) $ do
+    currentEnv <- gets bindings
+    -- Create RecClosures that share the same environment
+    let recEnv = Map.fromList [(v, RecClosure Map.empty v p e) | (Id v _ _, Lam (Id p _ _) e) <- bs]
+    -- Update the RecClosures with the complete recursive environment
+    let finalEnv = Map.union recEnv currentEnv
+    let finalClosures = Map.map (\(RecClosure _ n p b) -> RecClosure finalEnv n p b) recEnv
+
+    modify (\s -> s{bindings = Map.union finalClosures (bindings s)})
+
+-- | Load a module into the interpreter
 loadModule :: Interpreter r => CoreModule CoreBind -> Sem r ()
 loadModule (CoreModule _ decls) = do
-    bindings <-
-        traverse
-            ( \(CoreValue (NonRecursive (Id v _ _, e))) -> do
-                val <- interpretExpr e
-                pure (v, val)
-            )
-            decls
-    modify (\s -> s{bindings = Map.fromList bindings})
+    for_
+        decls
+        ( \(CoreValue v) -> do
+            interpretBinding v
+        )
     pure ()
+
+evalIO :: Interpreter r => Value -> Sem r Value
+evalIO (IOAction io) = do
+    val <- embed io
+    evalIO val
+evalIO other = pure other
 
 {- | Looks for a value Main.main in the bindings and runs it
 The module must have been already loaded
 -}
-run :: Interpreter r =>  Sem r ()
+run :: Interpreter r => Sem r ()
 run = do
     s <- get
     case Map.lookup (UnlocatedGlobal (Qualified "main" (ModuleName ("Main" :| [])))) (s.bindings) of
-        Just (Closure s' e) -> do
-            put s'
-            interpretExpr e
+        Just (val) -> do
+            evalIO val
             pure ()
-        _ -> error "No Main.main found"
+        _ -> throw $ NoMainFound s
 
 runInterpreter :: IsPipeline r => Sem (EffectsAsPrefixOf InterpreterEffects r) a -> Sem r a
 runInterpreter m = do
     let s = ElaraState{bindings = Map.empty}
-    subsume (runErrorOrReport $ evalState s m)
+    subsume $ subsume (runErrorOrReport $ evalState s m)

--- a/src/Elara/Interpreter.hs
+++ b/src/Elara/Interpreter.hs
@@ -241,6 +241,7 @@ interpretBinding (Recursive bs) = debugWith ("Interpreting letrec" <+> pretty bs
 -- | Load a module into the interpreter
 loadModule :: Interpreter r => CoreModule CoreBind -> Sem r ()
 loadModule (CoreModule name decls) = do
+    oldBindings <- gets bindings
     for_
         decls
         ( \case
@@ -249,7 +250,7 @@ loadModule (CoreModule name decls) = do
             (CoreType decl) -> loadTypeDecl decl
         )
     newEnv <- gets bindings
-    debug $ "Loaded module" <+> pretty name <+> "with bindings" <+> pretty newEnv
+    debug $ "Loaded module" <+> pretty name <+> "with bindings" <+> pretty (Map.difference newEnv oldBindings)
     pure ()
 
 loadTypeDecl :: Interpreter r => CoreTypeDecl -> Sem r ()

--- a/src/Elara/Interpreter.hs
+++ b/src/Elara/Interpreter.hs
@@ -101,6 +101,7 @@ primOps =
         [ ("==", 2)
         , ("+", 2)
         , (">>=", 2)
+        , ("stringCons", 2)
         ]
 
 boolValue :: Bool -> Value

--- a/src/Elara/Interpreter.hs
+++ b/src/Elara/Interpreter.hs
@@ -1,0 +1,91 @@
+-- | Simple interpreter for the Core language
+module Elara.Interpreter where
+
+import Data.Map qualified as Map
+import Elara.AST.Name (ModuleName (..), Qualified (..), VarName)
+import Elara.AST.VarRef
+import Elara.Core hiding (Literal (..))
+import Elara.Core qualified as Core
+import Elara.Core.Generic (Bind (..))
+import Elara.Core.Module
+import Elara.Pipeline
+import Elara.Prim.Core (unitCon)
+import Polysemy hiding (run)
+import Polysemy.State
+import Elara.Data.Pretty
+import Elara.Error (ReportableError, runErrorOrReport)
+import Polysemy.Error
+
+type Interpreter r = Members InterpreterEffects r
+
+type InterpreterEffects = [State ElaraState, Error InterpreterError, Embed IO]
+
+data ElaraState = ElaraState
+    { bindings :: Map (UnlocatedVarRef Text) Value
+    }
+    deriving (Generic)
+
+instance Pretty ElaraState
+
+data InterpreterError = 
+    UnboundVariable (UnlocatedVarRef Text)
+    | NotAClosure Value
+    deriving (Generic)
+
+instance Pretty InterpreterError
+
+instance ReportableError InterpreterError
+
+data Value
+    = Int Integer
+    | String Text
+    | Char Char
+    | Double Double
+    | Ctor TyCon [Value]
+    | Closure (ElaraState) CoreExpr
+    deriving (Generic)
+
+instance Pretty Value where
+
+
+interpretExpr :: Interpreter r => CoreExpr -> Sem r Value
+interpretExpr (Lit (Core.Int i)) = pure $ Int i
+interpretExpr (Lit (Core.String s)) = pure $ String s
+interpretExpr (Lit (Core.Char c)) = pure $ Char c
+interpretExpr (Lit (Core.Double d)) = pure $ Double d
+interpretExpr (Lit Core.Unit) = pure $ Ctor unitCon []
+interpretExpr (Var (Id v _ _)) = do
+    s <- get
+    case Map.lookup v (bindings s) of
+        Just val -> pure val
+        Nothing -> error $ "Unbound variable: " <> show v
+
+loadModule :: Interpreter r => CoreModule CoreBind -> Sem r ()
+loadModule (CoreModule _ decls) = do
+    bindings <-
+        traverse
+            ( \(CoreValue (NonRecursive (Id v _ _, e))) -> do
+                val <- interpretExpr e
+                pure (v, val)
+            )
+            decls
+    modify (\s -> s{bindings = Map.fromList bindings})
+    pure ()
+
+{- | Looks for a value Main.main in the bindings and runs it
+The module must have been already loaded
+-}
+run :: Interpreter r =>  Sem r ()
+run = do
+    s <- get
+    case Map.lookup (UnlocatedGlobal (Qualified "main" (ModuleName ("Main" :| [])))) (s.bindings) of
+        Just (Closure s' e) -> do
+            put s'
+            interpretExpr e
+            pure ()
+        _ -> error "No Main.main found"
+
+runInterpreter :: IsPipeline r => Sem (EffectsAsPrefixOf InterpreterEffects r) a -> Sem r a
+runInterpreter m = do
+    let s = ElaraState{bindings = Map.empty}
+    subsume (runErrorOrReport $ evalState s m)

--- a/src/Elara/Interpreter.hs
+++ b/src/Elara/Interpreter.hs
@@ -2,7 +2,7 @@
 module Elara.Interpreter where
 
 import Data.Map qualified as Map
-import Elara.AST.Name (ModuleName (..), Qualified (..), VarName)
+import Elara.AST.Name (ModuleName (..), Qualified (..))
 import Elara.AST.VarRef
 import Elara.Core hiding (Literal (..))
 import Elara.Core qualified as Core
@@ -10,14 +10,13 @@ import Elara.Core.Generic (Bind (..))
 import Elara.Core.Module
 import Elara.Data.Pretty
 import Elara.Error (ReportableError, runErrorOrReport)
-import Elara.Logging (StructuredDebug, debug, debugWith, structuredDebugToLog)
+import Elara.Logging (StructuredDebug, debug, debugWith)
 import Elara.Pipeline
 import Elara.Prim.Core (falseCtor, fetchPrimitiveName, trueCtor, unitCtor)
 import Polysemy hiding (run)
 import Polysemy.Error
 import Polysemy.State
 import Polysemy.State.Extra
-import Print (prettyToString)
 
 type Interpreter r = Members InterpreterEffects r
 

--- a/src/Elara/Interpreter.hs
+++ b/src/Elara/Interpreter.hs
@@ -114,6 +114,9 @@ interpretExpr (Lit (Core.Double d)) = pure $ Double d
 interpretExpr (Lit Core.Unit) = pure $ Ctor unitCtor []
 interpretExpr (App (Var (Id (UnlocatedGlobal primName) _ _)) (Lit (Core.String primArg))) | primName == fetchPrimitiveName = do
     pure $ PrimOp primArg
+-- elaraPrimitive should be called with a tyapp - i.e. `elaraPrimitive @T "f"`
+interpretExpr (App (TyApp (Var (Id (UnlocatedGlobal primName) _ _)) _) (Lit (Core.String primArg))) | primName == fetchPrimitiveName = do
+    pure $ PrimOp primArg
 interpretExpr (Var (Id v _ _)) = do
     s <- get
     case Map.lookup v (bindings s) of
@@ -218,6 +221,7 @@ interpretExpr (Match e of' alts) = debugWith ("Matching " <> pretty e) $ do
                 _ -> go rest
         go ((DEFAULT, _, branchBody) : _) = interpretExpr branchBody
     go alts
+interpretExpr (TyApp e _) = interpretExpr e -- lol
 interpretExpr other = throw $ UnhandledExpr other
 
 interpretBinding :: Interpreter r => CoreBind -> Sem r ()

--- a/src/Elara/Lexer/Utils.hs
+++ b/src/Elara/Lexer/Utils.hs
@@ -40,7 +40,7 @@ data ParseState = ParseState
     { _input :: AlexInput
     , _lexSC :: Int -- lexer start code
     , _stringBuf :: String -- temporary storage for strings
-    , _pendingTokens :: [Lexeme] -- right now used when Parser consumes the lookeahead and decided to put it back
+    , _pendingTokens :: [Lexeme] -- right now used when Parser consumes the lookahead and decided to put it back
     , _indentStack :: NonEmpty IndentInfo -- stack of indentation levels
     , _pendingPosition :: TokPosition -- needed when parsing strings, chars, multi-line strings
     }
@@ -223,8 +223,7 @@ Throws an error if the name is not qualified.
 Examples:
 
 >>> splitQualName "Hello.world"
-WAS (ModuleName ("Hello" :| []),"world")
-NOW *** Exception: /var/folders/gd/_tgnljw10lz_95rz3sv5bp4h0000gn/T/extra-file-91583352691-2909-2183: withFile: resource busy (file is locked)
+(ModuleName ("Hello" :| []),"world")
 
 >>> splitQualName "A.B.C"
 (ModuleName ("A" :| ["B"]),"C")

--- a/src/Elara/Logging.hs
+++ b/src/Elara/Logging.hs
@@ -1,6 +1,10 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+
 module Elara.Logging where
 
 import Elara.Data.Pretty
+import GHC.Exts
+import GHC.TypeLits (KnownSymbol (..), symbolVal)
 import Polysemy
 import Polysemy.Log qualified as Log
 import Polysemy.State (State, evalState, get, put)
@@ -54,3 +58,37 @@ ignoreStructuredDebug :: Sem (StructuredDebug : r) a -> Sem r a
 ignoreStructuredDebug = interpretH $ \case
     Debug _ -> pureT ()
     DebugWith _ act -> runTSimple act
+
+{- | Inspired by https://x.com/Quelklef/status/1860188828876583146 !
+A recursive, pure function, which can be traced with a monadic effect.
+-}
+type TraceableFn (name :: Symbol) a b = forall m. Monad m => (a -> m b) -> a -> m b
+
+-- | Purely run a traceable function, without any tracing
+runTraceable :: TraceableFn name a b -> a -> b
+runTraceable f a = runIdentity $ do
+    f' <- f (pure . runTraceable f) a
+    pure f'
+
+-- | Run a traceable function with structured debug tracing
+traceFn ::
+    forall (name :: Symbol) a b r.
+    (Pretty a, Pretty b, Member StructuredDebug r, KnownSymbol name) =>
+    TraceableFn name a b -> (a -> Sem r b)
+traceFn f a = do
+    let p = symbolVal (Proxy @name)
+    res <- debugWith (pretty p <> ":" <+> pretty a) $ do
+        f (traceFn @name @a @b @r f) a
+    debug $ pretty res
+    pure res
+
+fib :: TraceableFn "fib" Int Int
+fib _ 0 = pure 0
+fib _ 1 = pure 1
+fib f n = do
+    a <- f (n - 1)
+    b <- f (n - 2)
+    pure $ a + b
+
+x :: Sem '[StructuredDebug] Int
+x = traceFn @"fib" fib 10

--- a/src/Elara/Logging.hs
+++ b/src/Elara/Logging.hs
@@ -62,12 +62,13 @@ ignoreStructuredDebug = interpretH $ \case
 {- | Inspired by https://x.com/Quelklef/status/1860188828876583146 !
 A recursive, pure function, which can be traced with a monadic effect.
 -}
-type TraceableFn (name :: Symbol) a b = forall m. Monad m => (a -> m b) -> a -> m b
+newtype TraceableFn (name :: Symbol) a b
+    = TraceableFn (forall m. Monad m => (a -> m b) -> a -> m b)
 
 -- | Purely run a traceable function, without any tracing
 runTraceable :: TraceableFn name a b -> a -> b
-runTraceable f a = runIdentity $ do
-    f' <- f (pure . runTraceable f) a
+runTraceable (TraceableFn f) a = runIdentity $ do
+    f' <- f (pure . runTraceable (TraceableFn f)) a
     pure f'
 
 -- | Run a traceable function with structured debug tracing
@@ -75,20 +76,19 @@ traceFn ::
     forall (name :: Symbol) a b r.
     (Pretty a, Pretty b, Member StructuredDebug r, KnownSymbol name) =>
     TraceableFn name a b -> (a -> Sem r b)
-traceFn f a = do
+traceFn (TraceableFn f) a = do
     let p = symbolVal (Proxy @name)
     res <- debugWith (pretty p <> ":" <+> pretty a) $ do
-        f (traceFn @name @a @b @r f) a
+        f (traceFn @name (TraceableFn f)) a
     debug $ pretty res
     pure res
 
 fib :: TraceableFn "fib" Int Int
-fib _ 0 = pure 0
-fib _ 1 = pure 1
-fib f n = do
-    a <- f (n - 1)
-    b <- f (n - 2)
-    pure $ a + b
-
-x :: Sem '[StructuredDebug] Int
-x = traceFn @"fib" fib 10
+fib = TraceableFn $ \f n ->
+    case n of
+        0 -> pure 0
+        1 -> pure 1
+        _ -> do
+            a <- f (n - 1)
+            b <- f (n - 2)
+            pure $ a + b

--- a/src/Elara/Prim.hs
+++ b/src/Elara/Prim.hs
@@ -66,7 +66,7 @@ primitiveVars :: [VarName]
 primitiveVars = [fetchPrimitiveName]
 
 primitiveTypes :: [TypeName]
-primitiveTypes = [stringName, charName, intName, boolName, trueName, falseName, consName]
+primitiveTypes = [stringName, charName, intName, consName]
 
 primKindCheckContext :: Map (Qualified TypeName) ElaraKind
 primKindCheckContext =

--- a/src/Elara/Prim/Core.hs
+++ b/src/Elara/Prim/Core.hs
@@ -36,7 +36,7 @@ fetchPrimitiveName :: Qualified Text
 fetchPrimitiveName = Qualified "elaraPrimitive" (ModuleName ("Elara" :| ["Prim"]))
 
 boolCon :: TyCon
-boolCon = TyCon (mkPrimQual "Bool") Prim
+boolCon = TyCon (mkPrimQual "Bool") (TyADT [trueCtorName, falseCtorName])
 
 intCon :: TyCon
 intCon = TyCon (mkPrimQual "Int") Prim

--- a/src/Elara/Prim/Core.hs
+++ b/src/Elara/Prim/Core.hs
@@ -65,6 +65,12 @@ trueCtor = DataCon trueCtorName (ConTy boolCon) boolCon
 falseCtor :: DataCon
 falseCtor = DataCon falseCtorName (ConTy boolCon) boolCon
 
+unitCtor :: DataCon
+unitCtor = DataCon unitConName (ConTy unitCon) unitCon
+
+unitConName :: Qualified Text
+unitConName = mkPrimQual "()"
+
 undefinedId :: Member UniqueGen r => Sem r Var
 undefinedId = do
     a <- makeUnique (Just "a")

--- a/src/Elara/Rename.hs
+++ b/src/Elara/Rename.hs
@@ -504,7 +504,11 @@ renameDeclaration decl@(Declaration ld) = Declaration <$> traverseOf unlocated r
         withModified addAllVarAliases $ do
             ty' <- traverseOf unlocated (renameTypeDeclaration declModuleName) ty
             let ann' = coerceTypeDeclAnnotations ann
-            pure $ TypeDeclaration name vars' ty' ann'
+            thisModule <- askCurrentModule
+            let qualifiedName =
+                    sequenceA $
+                        Qualified name (thisModule ^. _Unwrapped % unlocated % field' @"name" % unlocated)
+            pure $ TypeDeclaration qualifiedName vars' ty' ann'
 
 renameTypeDeclaration :: InnerRename r => ModuleName -> DesugaredTypeDeclaration -> Sem r RenamedTypeDeclaration
 renameTypeDeclaration _ (Alias t) = do

--- a/src/Elara/Rename.hs
+++ b/src/Elara/Rename.hs
@@ -30,7 +30,7 @@ import Elara.Data.TopologicalGraph
 import Elara.Data.Unique (Unique, UniqueGen, makeUnique, uniqueGenToIO)
 import Elara.Error (ReportableError (report), runErrorOrReport, writeReport)
 import Elara.Error.Codes qualified as Codes
-import Elara.Logging (StructuredDebug, debug)
+import Elara.Logging (StructuredDebug, debug, debugWith)
 import Elara.Pipeline
 import Elara.Prim.Core (consCtorName, emptyListCtorName, tuple2CtorName)
 import Error.Diagnose (Marker (This, Where), Note (..), Report (Err))
@@ -527,9 +527,10 @@ renameSimpleType = traverseOf (_Unwrapped % _1 % unlocated) (renameType False)
 -- | Renames a type, qualifying type constructors and type variables where necessary
 renameType ::
     InnerRename r =>
-    -- | If new type variables are allowed - if False, this will throw an error if a type variable is not in scope
-    -- This is useful for type declarations, where something like @type Invalid a = b@ would clearly be invalid
-    -- But for local type annotations, we want to allow this, as it may be valid
+    {- | If new type variables are allowed - if False, this will throw an error if a type variable is not in scope
+    This is useful for type declarations, where something like @type Invalid a = b@ would clearly be invalid
+    But for local type annotations, we want to allow this, as it may be valid
+    -}
     Bool ->
     DesugaredType' ->
     Sem r RenamedType'
@@ -613,7 +614,7 @@ renameExpr (Expr le@(Located loc _, _)) =
             createConses [] = lastCons
             createConses (x' : xs') = cons x' (createConses xs')
         pure (createConses (toList xs') ^. _Unwrapped % _1 % unlocated)
-    renameExpr' (LetIn vn _ e body) = do
+    renameExpr' (LetIn vn _ e body) = debugWith ("renameExpr' " <> pretty vn) $ do
         vn' <- uniquify vn
         withModified (the @"varNames" %~ Map.insert (vn ^. unlocated) (one $ Local vn')) $ do
             exp' <- renameExpr e
@@ -761,13 +762,14 @@ desugarBlock (e@(Expr' (Let{})) :| []) = do
     decl <- ask @(Maybe DesugaredDeclaration)
     throw (BlockEndsWithLet e (fmap (view (_Unwrapped % unlocated % the @"body")) decl))
 desugarBlock (e :| []) = renameExpr e
-desugarBlock (Expr (Located l (Let n p val), a) :| (xs1 : xs')) = do
-    val' <- renameExpr val
-    a' <- traverse (traverseOf (_Unwrapped % _1 % unlocated) (renameType False)) a
+desugarBlock (exp@(Expr (Located l (Let n p val), a)) :| (xs1 : xs')) = debugWith ("desugarBlock: " <> pretty exp) $ do
     n' <- uniquify n
-    xs' <- withModified (the @"varNames" %~ Map.insert (n ^. unlocated) (one $ Local n')) $ do
-        desugarBlock (xs1 :| xs')
-    pure $ Expr (Located l (LetIn n' p val' xs'), a')
+    -- TODO this is almost identical to the normal let case
+    withModified (the @"varNames" %~ Map.insert (n ^. unlocated) (one $ Local n')) $ do
+        val' <- renameExpr val
+        a' <- traverse (traverseOf (_Unwrapped % _1 % unlocated) (renameType False)) a
+        block <- desugarBlock (xs1 :| xs')
+        pure $ Expr (Located l (LetIn n' p val' block), a')
 desugarBlock xs = do
     let loc = spanningRegion' (xs <&> (^. _Unwrapped % _1 % sourceRegion))
     xs' <- traverse renameExpr xs

--- a/src/Elara/Shunt.hs
+++ b/src/Elara/Shunt.hs
@@ -202,10 +202,10 @@ createOpTable prevOpTable graph = execState (maybeToMonoid prevOpTable) $ do
     addDeclsToOpTable' (Declaration (Located _ decl)) = do
         case decl ^. field' @"body" % _Unwrapped % unlocated of
             Value{_valueName, _valueAnnotations = (ValueDeclAnnotations (Just fixity))} ->
-                let nameRef :: IgnoreLocVarRef Name = Global $ IgnoreLocation $ (NVarName <<$>> _valueName)
+                let nameRef = Global $ IgnoreLocation $ (NVarName <<$>> _valueName)
                  in modify $ Map.insert nameRef (infixDeclToOpInfo fixity)
             TypeDeclaration name _ _ (TypeDeclAnnotations (Just fixity) NoFieldValue) ->
-                let nameRef :: IgnoreLocVarRef Name = Global $ IgnoreLocation $ (sequenceA $ (Qualified (NTypeName <$> name) (decl ^. field' @"moduleName" % unlocated)))
+                let nameRef = Global $ IgnoreLocation $ (((NTypeName <<$>> name)))
                  in modify $ Map.insert nameRef (infixDeclToOpInfo fixity)
             _ -> pass
 

--- a/src/Elara/ToCore.hs
+++ b/src/Elara/ToCore.hs
@@ -307,9 +307,11 @@ desugarMatch e pats = do
             AST.UnitPattern -> pure (Core.LitAlt Core.Unit, [])
             AST.WildcardPattern -> pure (Core.DEFAULT, [])
             AST.VarPattern (Located _ vn) -> pure (Core.DEFAULT, [Core.Id (UnlocatedLocal (view (to nameText) <$> vn)) t' Nothing])
-            AST.ConstructorPattern cn pats -> do
+            AST.ConstructorPattern cn pats -> debugWithResult ("patternToCore (ConstructorPattern): cn =" <+> pretty cn) $ do
                 c <- lookupCtor cn
+                debug ("patternToCore (ConstructorPattern): c =" <+> pretty c)
                 pats' <- for pats patternToCore
+                debug ("patternToCore (ConstructorPattern): pats' =" <+> pretty pats')
                 pure (Core.DataAlt c, pats' >>= snd)
 
 mkBindName :: InnerToCoreC r => TypedExpr -> Sem r Var

--- a/src/Elara/ToCore.hs
+++ b/src/Elara/ToCore.hs
@@ -182,7 +182,7 @@ moduleToCore (Module (Located _ m)) = do
     pure $ CoreModule name (catMaybes decls)
 
 typedTvToCoreTv :: ASTLocate 'Typed (Select "TypeVar" 'Typed) -> Core.TypeVariable
-typedTvToCoreTv (Located _ ((n :: Unique LowerAlphaName))) = TypeVariable (Just . nameText <$> n) TypeKind
+typedTvToCoreTv (Located _ tv) = TypeVariable tv TypeKind
 
 typeToCore :: HasCallStack => InnerToCoreC r => Type.Monotype SourceRegion -> Sem r Core.Type
 typeToCore (Type.TypeVar (Type.SkolemVar v)) = pure $ Core.TyVarTy $ TypeVariable v TypeKind

--- a/src/Elara/ToCore.hs
+++ b/src/Elara/ToCore.hs
@@ -175,7 +175,7 @@ moduleToCore (Module (Located _ m)) = debugWith ("Converting module: " <> pretty
                                 (Core.ForAllTy . mkTypeVar . view unlocated)
                                 ( foldr
                                     Core.FuncTy
-                                    (foldr (flip Core.AppTy . TyVarTy . mkTypeVar . view unlocated) (ConTy tyCon) tvs)
+                                    (flipfoldl' (flip Core.AppTy . TyVarTy . mkTypeVar . view unlocated) (ConTy tyCon) tvs)
                                     ctorArgs'
                                 )
                                 tvs

--- a/src/Elara/ToCore/Match.hs
+++ b/src/Elara/ToCore/Match.hs
@@ -1,0 +1,320 @@
+{-# LANGUAGE PatternSynonyms #-}
+
+{- |
+Maranget-style pattern match compilation using a compact pattern matrix.
+
+This module normalises surface patterns into 'NPat' and compiles a matrix
+of such patterns into Core case expressions. We store the rectangular grid
+of patterns in a 'Data.Matrix.Matrix', while per-row metadata (RHS payloads
+and accumulated variable bindings) are kept in parallel lists aligned by
+row index.
+
+Key points:
+- We always discriminate on column 0 (the head scrutinee) and recursively
+  refine the matrix.
+- Variable patterns behave as wildcards for decision making, but we record
+  their binds and emit them as nested non-recursive Core lets at leaves.
+- Constructor alternatives extend the scrutinee list with freshly bound
+  field variables and push their argument patterns into the matrix.
+-}
+module Elara.ToCore.Match where
+
+import Data.Map.Strict qualified as M
+import Data.Matrix qualified as Mat
+import Data.Text qualified as T
+import Elara.AST.Generic.Types qualified as AST
+import Elara.AST.Name (NameLike (..), Qualified, VarName)
+import Elara.AST.Region
+import Elara.AST.Typed as Typed
+import Elara.AST.VarRef (UnlocatedVarRef, pattern UnlocatedLocal)
+import Elara.Core qualified as Core
+import Elara.Core.Generic qualified as G
+import Elara.Data.Unique (Unique)
+import Polysemy.State ()
+
+{- Our initial step in compiling pattern matching is to construct a pattern matrix
+of the patterns used in a match
+For example, consider the following code:
+@
+f l = match l with
+    (Nil, _) -> x
+    (_, Nil) -> y
+    (Cons x xs, Cons y ys) -> z
+@
+
+The ultimate goal with this desugaring process is to turn all pattern matching into simple matches upon either:
+- A single value
+- A constructor with its values bound as variables
+
+For example, the above code would be desugared into something like:
+@
+f l = match l with
+    (x, y) -> match x with
+        Nil -> x
+        _ -> match y with
+            Nil -> y
+            _ -> z
+@
+
+however this is difficult to do in a single pass.
+
+Basic pattern-matrix construction
+
+We define a small normalized pattern language (NPat) that abstracts over the
+surface TypedPattern forms but keeps exactly the information a matrix needs:
+
+- Wildcards/variables as default-able cases (we record var names for later binds)
+- Literals as equality-discriminated heads
+- Constructors with their subpatterns (still in NPat form). We keep the
+  constructor as a qualified Text (no DataCon resolution here) to avoid
+  coupling and cycles; resolution can happen later when building Core.
+
+For now we build a single-column matrix since `match` in the current AST
+matches one scrutinee. Product (tuple/record) expansion can be layered on later
+by transforming the first column.
+-}
+
+-- | Normalized pattern
+data NPat
+    = PWild
+    | PVar (Unique VarName) -- variable bind; treated like wildcard for the decision tree
+    | PLit Core.Literal -- literal match
+    | PCon (Qualified Text) [NPat] -- constructor with subpatterns
+    deriving (Show, Eq)
+
+{- | Pattern matrix backed by 'Data.Matrix'. Invariant:
+  nrows pmPats == length pmRhs == length pmBinds
+-}
+data PMatrix a = PMatrix
+    { pmPats :: Mat.Matrix NPat
+    , pmRhs :: [a]
+    , pmBinds :: [[(Unique VarName, Core.Var)]]
+    }
+    deriving (Show, Eq)
+
+{- | Build a single-column pattern matrix from branches (pattern, rhs).
+The RHS is left polymorphic so callers can carry either TypedExpr or CoreExpr.
+-}
+buildMatrix1 :: [(TypedPattern, a)] -> PMatrix a
+buildMatrix1 branches =
+    let pats = Mat.fromList (length branches) 1 (map (toNPat . fst) branches)
+        rhs = map snd branches
+        binds = replicate (length branches) []
+     in PMatrix{pmPats = pats, pmRhs = rhs, pmBinds = binds}
+
+-- | Convert a TypedPattern into our normalized NPat form.
+toNPat :: TypedPattern -> NPat
+toNPat (AST.Pattern (Located _ pat, _t)) = go pat
+  where
+    go = \case
+        AST.IntegerPattern i -> PLit (Core.Int i)
+        AST.FloatPattern f -> PLit (Core.Double f)
+        AST.StringPattern s -> PLit (Core.String s)
+        AST.CharPattern c -> PLit (Core.Char c)
+        AST.UnitPattern -> PLit Core.Unit
+        AST.WildcardPattern -> PWild
+        AST.VarPattern (Located _ uvn) -> PVar uvn
+        AST.ConstructorPattern (Located _ qn) ps ->
+            PCon (fmap nameText qn) (map toNPat ps)
+
+-- No explicit partition/drop helpers are needed with the matrix-based layout.
+
+{-
+  Minimal compiler from a PMatrix to Core.
+  - Single scrutinee to start; after matching a constructor with n fields we
+    extend the scrutinee list with the freshly-bound field variables before the
+    remaining columns. We always discriminate on column 0.
+  - Variable patterns are currently treated as wildcards; binding them to user
+    names can be layered in later by threading a bind-env per row and emitting
+    Let at leaves.
+-}
+
+type ConResolver m = Qualified Text -> m Core.DataCon
+
+type FreshLocal m = T.Text -> Core.Type -> m Core.Var
+
+{- | Compile a pattern matrix to a Core expression. Assumes the first column
+corresponds to the head scrutinee in the provided list of variables.
+-}
+compileMatrix :: Monad m => ConResolver m -> FreshLocal m -> [Core.Var] -> PMatrix Core.CoreExpr -> m Core.CoreExpr
+compileMatrix resolveCon fresh scruts pm =
+    if Mat.ncols pm.pmPats == 0
+        then case (pm.pmRhs, pm.pmBinds) of
+            (rhs0 : _, binds0 : _) -> pure (emitBinds binds0 rhs0)
+            _ -> pure (Core.Lit Core.Unit)
+        else stepOnColumn0 resolveCon fresh scruts pm
+
+stepOnColumn0 :: Monad m => ConResolver m -> FreshLocal m -> [Core.Var] -> PMatrix Core.CoreExpr -> m Core.CoreExpr
+stepOnColumn0 resolveCon fresh scruts pm = do
+    case scruts of
+        [] ->
+            -- No scrutinee left. If matrix is solved, emit first row; else Unit.
+            if Mat.ncols pm.pmPats == 0
+                then case (pm.pmRhs, pm.pmBinds) of
+                    (rhs0 : _, binds0 : _) -> pure (emitBinds binds0 rhs0)
+                    _ -> pure (Core.Lit Core.Unit)
+                else pure (Core.Lit Core.Unit)
+        s0 : restScruts -> do
+            let rows = Mat.nrows pm.pmPats
+                cols = Mat.ncols pm.pmPats
+                rowInfo i =
+                    if cols == 0
+                        then Nothing
+                        else
+                            let p0 = Mat.getElem i 1 pm.pmPats
+                                ps = [Mat.getElem i j pm.pmPats | j <- [2 .. cols]]
+                             in Just (p0, ps)
+                foldPart i (consM, litM, defs) =
+                    case rowInfo i of
+                        Nothing -> (consM, litM, defs)
+                        Just (p0, ps) -> case p0 of
+                            PCon qn args ->
+                                let entry = (i, args, ps)
+                                 in (M.insertWith (++) qn [entry] consM, litM, defs)
+                            PLit l ->
+                                let entry = (i, ps)
+                                 in (consM, M.insertWith (++) l [entry] litM, defs)
+                            PWild -> (consM, litM, (i, p0, ps) : defs)
+                            PVar _ -> (consM, litM, (i, p0, ps) : defs)
+                (consM, litM, defs) = foldr foldPart (M.empty, M.empty, []) [1 .. rows]
+
+            if not (M.null consM)
+                then do
+                    conAlts <- forM (M.toList consM) $ \(qn, matched) -> do
+                        dc <- resolveCon qn
+                        let argTys = Core.functionTypeArgs (Core.dataConType dc)
+                        xs <- forM (zip [0 ..] argTys) $ \(i, ty) -> fresh ("p" <> show i) ty
+                        let n = length xs
+                            transformMatched (i, args, tailPs) =
+                                let (args', addBinds) = bindImmediate xs args
+                                    newRow = args' ++ tailPs
+                                    rhsRow = at1 i pm.pmRhs
+                                    bindsRow = addBinds ++ at1 i pm.pmBinds
+                                 in (newRow, rhsRow, bindsRow)
+                            transformDefault (i, headPat, tailPs) =
+                                let pad = replicate n PWild
+                                    newRow = pad ++ tailPs
+                                    rhsRow = at1 i pm.pmRhs
+                                    bindsRow = case headPat of
+                                        PVar u -> (u, s0) : at1 i pm.pmBinds
+                                        _ -> at1 i pm.pmBinds
+                                 in (newRow, rhsRow, bindsRow)
+                            rowsForAlt = map transformMatched matched ++ map transformDefault defs
+                        body <-
+                            if null rowsForAlt
+                                then pure (Core.Lit Core.Unit)
+                                else do
+                                    let newPats = Mat.fromLists (map (\(r, _, _) -> r) rowsForAlt)
+                                        newRhs = map (\(_, r, _) -> r) rowsForAlt
+                                        newBs = map (\(_, _, b) -> b) rowsForAlt
+                                    compileMatrix resolveCon fresh (xs ++ restScruts) PMatrix{pmPats = newPats, pmRhs = newRhs, pmBinds = newBs}
+                        pure (Core.DataAlt dc, xs, body)
+                    defAlt <- compileDefault resolveCon fresh s0 restScruts pm defs
+                    pure $ Core.Match (Core.Var s0) (Just s0) (conAlts ++ maybe [] (: []) defAlt)
+                else
+                    if not (M.null litM)
+                        then do
+                            litAlts <- forM (M.toList litM) $ \(l, matched) -> do
+                                let transformMatched (i, tailPs) =
+                                        let rhsRow = at1 i pm.pmRhs
+                                            bindsRow = at1 i pm.pmBinds
+                                         in (tailPs, rhsRow, bindsRow)
+                                    transformDefault (i, headPat, tailPs) =
+                                        let rhsRow = at1 i pm.pmRhs
+                                            bindsRow = case headPat of
+                                                PVar u -> (u, s0) : at1 i pm.pmBinds
+                                                _ -> at1 i pm.pmBinds
+                                         in (tailPs, rhsRow, bindsRow)
+                                    rowsForAlt = map transformMatched matched ++ map transformDefault defs
+                                body <-
+                                    if null rowsForAlt
+                                        then pure (Core.Lit Core.Unit)
+                                        else do
+                                            let newPats = Mat.fromLists (map (\(r, _, _) -> r) rowsForAlt)
+                                                newRhs = map (\(_, r, _) -> r) rowsForAlt
+                                                newBs = map (\(_, _, b) -> b) rowsForAlt
+                                            compileMatrix resolveCon fresh restScruts PMatrix{pmPats = newPats, pmRhs = newRhs, pmBinds = newBs}
+                                pure (Core.LitAlt l, [], body)
+                            defAlt <- compileDefault resolveCon fresh s0 restScruts pm defs
+                            pure $ Core.Match (Core.Var s0) (Just s0) (litAlts ++ maybeToList defAlt)
+                        else do
+                            -- Only defaults (wild/var). Drop head and continue.
+                            let transformDefault (i, headPat, tailPs) =
+                                    let rhsRow = at1 i pm.pmRhs
+                                        bindsRow = case headPat of
+                                            PVar u -> (u, s0) : at1 i pm.pmBinds
+                                            _ -> at1 i pm.pmBinds
+                                     in (tailPs, rhsRow, bindsRow)
+                                rowsOnlyDef = map transformDefault defs
+                            if null rowsOnlyDef
+                                then pure (Core.Lit Core.Unit)
+                                else do
+                                    let newPats = Mat.fromLists (map (\(r, _, _) -> r) rowsOnlyDef)
+                                        newRhs = map (\(_, r, _) -> r) rowsOnlyDef
+                                        newBs = map (\(_, _, b) -> b) rowsOnlyDef
+                                    compileMatrix resolveCon fresh restScruts PMatrix{pmPats = newPats, pmRhs = newRhs, pmBinds = newBs}
+  where
+    -- Bind immediate constructor-argument PVars to the provided xs.
+    bindImmediate :: [Core.Var] -> [NPat] -> ([NPat], [(Unique VarName, Core.Var)])
+    bindImmediate xs args =
+        let step (x, p) = case p of
+                PVar u -> (PWild, Just (u, x))
+                other -> (other, Nothing)
+            (args', newBinds) = unzip (zipWith (curry step) xs args)
+         in (args', catMaybes newBinds)
+
+{- | Build a DEFAULT alternative when default rows exist.
+  'defs' contains triples of (rowIndex, headPat, tailPatterns)
+-}
+compileDefault ::
+    Monad m =>
+    ConResolver m ->
+    FreshLocal m ->
+    Core.Var ->
+    [Core.Var] ->
+    PMatrix Core.CoreExpr ->
+    [(Int, NPat, [NPat])] ->
+    m (Maybe Core.CoreAlt)
+compileDefault resolveCon fresh s0 restScruts pm defs =
+    case defs of
+        [] -> pure Nothing
+        ds -> do
+            let rows' =
+                    [ ( tailPs
+                      , at1 i pm.pmRhs
+                      , case headPat of
+                            PVar u -> (u, s0) : at1 i pm.pmBinds
+                            _ -> at1 i pm.pmBinds
+                      )
+                    | (i, headPat, tailPs) <- ds
+                    ]
+                newPats = Mat.fromLists (map (\(r, _, _) -> r) rows')
+                newRhs = map (\(_, r, _) -> r) rows'
+                newBs = map (\(_, _, b) -> b) rows'
+            body <-
+                if Mat.nrows newPats == 0
+                    then pure (Core.Lit Core.Unit)
+                    else compileMatrix resolveCon fresh restScruts PMatrix{pmPats = newPats, pmRhs = newRhs, pmBinds = newBs}
+            pure (Just (Core.DEFAULT, [], body))
+
+-- Emit nested non-recursive lets for collected variable bindings.
+emitBinds :: [(Unique VarName, Core.Var)] -> Core.CoreExpr -> Core.CoreExpr
+emitBinds [] body = body
+emitBinds bs body =
+    let mkBinder :: (Unique VarName, Core.Var) -> Maybe Core.Var
+        mkBinder (u, v) = case v of
+            Core.Id _ ty _ ->
+                let uqText = fmap nameText u
+                    b :: UnlocatedVarRef Text
+                    b = UnlocatedLocal uqText
+                 in Just (Core.Id b ty Nothing)
+            Core.TyVar _ -> Nothing
+        mkLet (b, v) = Core.Let (G.NonRecursive (b, Core.Var v))
+        pairs = [(b, v) | p <- bs, let (_, v) = p, Just b <- [mkBinder p]]
+     in foldr mkLet body pairs
+
+-- 1-based indexing helper aligned with Data.Matrix row indices.
+at1 :: Int -> [a] -> a
+at1 i xs = case drop (i - 1) xs of
+    (y : _) -> y
+    [] -> error "PMatrix row index out of bounds"

--- a/src/Elara/TypeInfer.hs
+++ b/src/Elara/TypeInfer.hs
@@ -169,7 +169,7 @@ inferValue valueName valueExpr expectedType = do
     expected <- case expectedType of
         Just t -> pure t
         Nothing -> Lifted . TypeVar . UnificationVar <$> makeUniqueTyVar
-    expectedAsMono <- instantiate expected
+    (expectedAsMono, tyApps) <- instantiate expected
     addType' (TermVarKey (valueName)) expected
     (constraint, (typedExpr, t)) <- listen $ generateConstraints valueExpr
 

--- a/src/Elara/TypeInfer.hs
+++ b/src/Elara/TypeInfer.hs
@@ -111,7 +111,7 @@ inferDeclaration (Declaration ld) = do
             (typedExpr, polytype) <- inferValue (name ^. unlocated) e expectedType
             debug $ "Inferred type for " <> pretty name <> ": " <> pretty polytype
             addType' (TermVarKey (name ^. unlocated)) (Polytype polytype)
-            pure (Value name typedExpr NoFieldValue NoFieldValue (Generic.coerceValueDeclAnnotations annotations))
+            pure (Value name typedExpr NoFieldValue (Polytype polytype) (Generic.coerceValueDeclAnnotations annotations))
         TypeDeclaration (name) tyVars body anns -> do
             (kind, decl') <- (inferKind (name ^. unlocated) tyVars (body ^. unlocated))
             case decl' of

--- a/src/Elara/TypeInfer/ConstraintGeneration.hs
+++ b/src/Elara/TypeInfer/ConstraintGeneration.hs
@@ -22,6 +22,7 @@ import Elara.Data.Unique (uniqueGenToIO)
 import Elara.Error (ReportableError (..), defaultReport, runErrorOrReport, writeReport)
 import Elara.Logging (StructuredDebug, debug, debugWith, debugWithResult)
 import Elara.Pipeline
+import Elara.Prim (boolName, mkPrimQual)
 import Elara.TypeInfer.Environment (LocalTypeEnvironment, TypeEnvKey (..), addLocalType, emptyLocalTypeEnvironment, emptyTypeEnvironment, lookupLocalVar, lookupType, withLocalType)
 import Elara.TypeInfer.Ftv (Ftv (..), Fuv (fuv))
 import Elara.TypeInfer.Generalise (generalise)
@@ -152,7 +153,7 @@ generateConstraints' expr' = debugWithResult ("generateConstraints: " <> pretty 
             (typedThen, thenType) <- generateConstraints then'
             (typedElse, elseType) <- generateConstraints else'
 
-            let equalityConstraint = Equality condType (Scalar ScalarBool)
+            let equalityConstraint = Equality condType (TypeConstructor (mkPrimQual boolName) [])
             tell equalityConstraint
 
             let equalityConstraint1 = Equality thenType elseType

--- a/src/Elara/TypeInfer/ConstraintGeneration.hs
+++ b/src/Elara/TypeInfer/ConstraintGeneration.hs
@@ -88,7 +88,7 @@ generateConstraints' expr' = debugWithResult ("generateConstraints: " <> pretty 
             -- (ν:∀a.Q1 ⇒ τ1) ∈ Γ
             (instantiated, tyApps) <- instantiate varType
 
-            let instantiated' = (Var v', instantiated)
+            let instantiated' = (Var (Located loc (varName, varType)), instantiated)
 
             let withApps =
                     foldl'

--- a/src/Elara/TypeInfer/ConstraintGeneration.hs
+++ b/src/Elara/TypeInfer/ConstraintGeneration.hs
@@ -422,7 +422,7 @@ unifyVar a t = do
     bindVar tv t | member tv (fuv t) = throw (OccursCheckFailed (UnificationVar tv) t)
     bindVar tv t = do
         tch <- ask
-        debug ("bindVar " <> pretty tv <> " to " <> pretty t <> " with " <> pretty tch)
+        debug ("bindVar " <> pretty tv <> " to " <> pretty t)
         if member tv tch
             then pure (mempty, substitution (tv, t))
             else pure (Equality (TypeVar $ UnificationVar tv) t, mempty)
@@ -451,7 +451,7 @@ data UnifyError loc
     | UnificationFailed (Monotype loc, Monotype loc)
     | UnifyMismatch
     | UnresolvedConstraint (Qualified VarName) (Constraint SourceRegion)
-    deriving (Generic)
+    deriving (Generic, Show)
 
 instance Pretty (UnifyError loc)
 

--- a/src/Elara/TypeInfer/Convert.hs
+++ b/src/Elara/TypeInfer/Convert.hs
@@ -5,12 +5,12 @@ import Elara.AST.Generic.Types qualified as Generic
 import Elara.AST.Name
 import Elara.AST.Region (Located (..), SourceRegion, unlocated)
 import Elara.AST.Shunted (ShuntedType, ShuntedType')
+import Elara.Data.Pretty
 import Elara.Error (ReportableError (..))
 import Elara.Prim (boolName, charName, intName, mkPrimQual, stringName)
 import Elara.TypeInfer.Type
 import Polysemy
 import Polysemy.Error
-import Elara.Data.Pretty
 
 astTypeToGeneralisedInferType :: Member (Error TypeConvertError) r => ShuntedType -> Sem r (Type SourceRegion)
 astTypeToGeneralisedInferType t@(Generic.Type (Located loc t', kind)) = do

--- a/src/Elara/TypeInfer/Convert.hs
+++ b/src/Elara/TypeInfer/Convert.hs
@@ -38,7 +38,7 @@ convertTyVar name = fmap (Just . nameText) (name ^. unlocated)
 
 astTypeToInferType' :: Member (Error TypeConvertError) r => SourceRegion -> KindedType' -> Sem r (Monotype SourceRegion)
 astTypeToInferType' loc (Generic.TypeVar name) = do
-    pure $ TypeVar $ SkolemVar $ convertTyVar name -- idk if this should ever be a type variable? i dont think so
+    pure $ TypeVar $ UnificationVar $ convertTyVar name -- idk if this should ever be a skolem variable? i dont think so
 astTypeToInferType' loc (Generic.FunctionType i o) = do
     i' <- astTypeToInferType i
     o' <- astTypeToInferType o

--- a/src/Elara/TypeInfer/Convert.hs
+++ b/src/Elara/TypeInfer/Convert.hs
@@ -66,8 +66,6 @@ astTypeToInferType' loc (Generic.UserDefinedType (Located _ name)) | name == mkP
     pure $ Scalar ScalarString
 astTypeToInferType' loc (Generic.UserDefinedType (Located _ name)) | name == mkPrimQual intName = do
     pure $ Scalar ScalarInt
-astTypeToInferType' loc (Generic.UserDefinedType (Located _ name)) | name == mkPrimQual boolName = do
-    pure $ Scalar ScalarBool
 astTypeToInferType' loc (Generic.UserDefinedType (Located _ name)) | name == mkPrimQual charName = do
     pure $ Scalar ScalarChar
 

--- a/src/Elara/TypeInfer/Environment.hs
+++ b/src/Elara/TypeInfer/Environment.hs
@@ -39,6 +39,7 @@ instance Pretty (TypeEnvKey loc) where
 addType :: TypeEnvKey loc -> Type loc -> TypeEnvironment loc -> TypeEnvironment loc
 addType key ty (TypeEnvironment env) = TypeEnvironment (Map.insert key ty env)
 
+addType' :: Member (State (TypeEnvironment loc)) r => TypeEnvKey loc -> Type loc -> Sem r ()
 addType' key ty = modify (addType key ty)
 
 lookupType ::

--- a/src/Elara/TypeInfer/Generalise.hs
+++ b/src/Elara/TypeInfer/Generalise.hs
@@ -26,6 +26,7 @@ generalise ty = do
     let generalized = Forall (toList uniVars) EmptyConstraint ty
     pure generalized
 
+removeSkolems :: Monotype loc -> Monotype loc
 removeSkolems ty = do
     let ftvs = ftv ty
 

--- a/src/Elara/TypeInfer/Generalise.hs
+++ b/src/Elara/TypeInfer/Generalise.hs
@@ -5,12 +5,12 @@ import Data.Set (difference, member)
 import Elara.AST.Region
 import Elara.Data.Pretty
 import Elara.Logging
+import Elara.TypeInfer.Environment
 import Elara.TypeInfer.Ftv
 import Elara.TypeInfer.Monad
 import Elara.TypeInfer.Type
 import Polysemy hiding (transform)
 import Polysemy.State
-import Elara.TypeInfer.Environment
 
 generalise :: forall r. Infer SourceRegion r => Monotype SourceRegion -> Sem r (Polytype SourceRegion)
 generalise ty = do

--- a/src/Elara/TypeInfer/Type.hs
+++ b/src/Elara/TypeInfer/Type.hs
@@ -87,7 +87,6 @@ data Scalar
     | ScalarString
     | ScalarChar
     | ScalarUnit
-    | ScalarBool
     deriving (Generic, Show, Eq, Ord, Enum, Bounded)
 
 type DataCon = Qualified TypeName
@@ -139,7 +138,6 @@ instance Pretty Scalar where
     pretty ScalarString = Style.scalar "String"
     pretty ScalarChar = Style.scalar "Char"
     pretty ScalarUnit = Style.scalar "Unit"
-    pretty ScalarBool = Style.scalar "Bool"
 
 instance Pretty loc => Pretty (Type loc) where
     pretty (Polytype poly) = pretty poly

--- a/src/Elara/TypeInfer/Type.hs
+++ b/src/Elara/TypeInfer/Type.hs
@@ -80,6 +80,10 @@ data Monotype (loc :: Kind.Type)
       Function (Monotype loc) (Monotype loc)
     deriving (Generic, Show, Eq, Ord)
 
+functionMonotypeResult :: Monotype loc -> Monotype loc
+functionMonotypeResult = \case
+    Function _ b -> functionMonotypeResult b
+    t -> t
 -- | A scalar type
 data Scalar
     = ScalarInt

--- a/src/Print.hs
+++ b/src/Print.hs
@@ -6,13 +6,13 @@ module Print where
 
 import Debug.Pretty.Simple (pTraceOptM, pTraceShowOptM)
 import Elara.Data.Pretty
-import Prettyprinter.Render.Terminal (putDoc)
 import Text.Pretty.Simple (
     CheckColorTty (NoCheckColorTty),
     defaultOutputOptionsDarkBg,
     pPrintOpt,
     pShow,
  )
+import qualified Elara.Width as Width
 
 elaraDebug :: Bool
 elaraDebug = True
@@ -22,7 +22,9 @@ printColored :: (Show a, MonadIO m) => a -> m ()
 printColored = pPrintOpt NoCheckColorTty defaultOutputOptionsDarkBg
 
 printPretty :: (Pretty a, MonadIO m) => a -> m ()
-printPretty p = liftIO (putDoc (pretty p) *> putStrLn "")
+printPretty p = liftIO $ do
+    width <- Width.getWidth 
+    putTextLn $ renderStrict True width (pretty p)
 
 showColored :: (Show a, IsString s) => a -> s
 showColored = fromString . toString . pShow

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,17 +1,16 @@
 packages:
   - .
 
-snapshot: nightly-2024-10-24 # GHC 9.6.4
-compiler: ghc-9.10.1 # Comes with Cabal-3.10.3.0
-
+snapshot: nightly-2025-08-30
+compiler: ghc-9.12.2 
 
 flags:
   diagnose:
     megaparsec-compat: true
   unix:
     os-string: true
-  file-io:
-    os-string: true
+#  file-io:
+#    os-string: true
   directory:
     os-string: true
 
@@ -35,12 +34,13 @@ extra-deps:
 - git: https://github.com/bristermitten/diagnose.git
   commit: 3dac026c9663f041d0e5df77b73053ff5627af4b
 
-- Cabal-3.12.1.0
-- Cabal-syntax-3.12.1.0
 - directory-1.3.8.3
 - filepath-1.5.2.0
 - haskeline-0.8.2.1
 - process-1.6.19.0
 - unix-2.8.5.1
 - attoparsec-0.14.4
-- polysemy-time-0.7.0.0@sha256:da0a87c16fa520710e883e9669d55ea262643783eda492d1a1bc7b1a3cc63786,4123
+
+- Cabal-3.14.2.0@sha256:f98aa86a37b9920dc6dfc8d79119a10df69542734f158a1c66ff144592f1d004,14148
+- polysemy-time-0.7.0.1@sha256:d702e9ca40ef76c3ef04845f4290d3d2db9745a82b670d8acef7521d107b1d0f,4123
+- Cabal-syntax-3.14.2.0@sha256:16766e2cd18f98bf259d2caf2b507764ebdfff0b16c2fb5b293fc57c1137af6f,7380

--- a/stdlib/list.elr
+++ b/stdlib/list.elr
@@ -1,2 +1,11 @@
 module List
 import Elara.Prim
+
+
+
+
+def map : (a -> b) -> List a -> List b
+let map f l =
+    match l with
+        Nil -> Nil
+        Cons x xs -> Cons (f x) (map f xs)

--- a/stdlib/list.elr
+++ b/stdlib/list.elr
@@ -1,11 +1,22 @@
 module List
 import Elara.Prim
+import Tuple
+import String
 
+def zip : List a -> List b -> List (Tuple2 a b)
+let zip l1 l2 =
+    match (l1, l2) with
+        Tuple2 Nil _ -> Nil
+        Tuple2 _ Nil -> Nil
+        Tuple2 (Cons x xs) (Cons y ys) -> Cons (Tuple2 x y) (zip xs ys)
 
-
-
-def map : (a -> b) -> List a -> List b
-let map f l =
+def listToString : List a -> String
+let listToString l =
+    let go l_ =
+        match l_ with
+            Nil -> ""
+            Cons x Nil -> toString x
+            Cons x xs -> toString x ++ ", " ++ go xs
     match l with
-        Nil -> Nil
-        Cons x xs -> Cons (f x) (map f xs)
+            Nil -> "[]"
+            Cons x xs -> "[" ++ go (Cons x xs) ++ "]"

--- a/stdlib/option.elr
+++ b/stdlib/option.elr
@@ -1,1 +1,10 @@
 module Option
+import Elara.Prim
+
+type Option a = Some a | None
+
+def isSome : Option a -> Bool
+let isSome opt =
+    match opt with
+        Some _ -> True
+        None -> False

--- a/stdlib/prelude.elr
+++ b/stdlib/prelude.elr
@@ -2,3 +2,6 @@ module Prelude
 import Elara.Prim
 import List
 
+
+def (|>) : a -> (a -> b) -> b
+let (|>) x f = f x

--- a/stdlib/prelude.elr
+++ b/stdlib/prelude.elr
@@ -5,3 +5,6 @@ import List
 
 def (|>) : a -> (a -> b) -> b
 let (|>) x f = f x
+
+def (*>) : IO a -> IO b -> IO b
+let (*>) = \x y -> x >>= \_ -> y

--- a/stdlib/prim.elr
+++ b/stdlib/prim.elr
@@ -15,3 +15,6 @@ let elaraPrimitive = elaraPrimitive
 
 def println : a -> IO ()
 let println = elaraPrimitive "println"
+
+def (>>=) : IO a -> (a -> IO b) -> IO b
+let (>>=) = elaraPrimitive ">>="

--- a/stdlib/prim.elr
+++ b/stdlib/prim.elr
@@ -8,3 +8,6 @@ let (==) = elaraPrimitive "=="
 
 def elaraPrimitive : String -> a
 let elaraPrimitive = elaraPrimitive
+
+def println : a -> IO ()
+let println = elaraPrimitive "println"

--- a/stdlib/prim.elr
+++ b/stdlib/prim.elr
@@ -4,6 +4,9 @@ type Bool = True | False
 
 type List a = Nil | Cons a (List a)
 
+type Tuple2 a b = Tuple2 a b
+
+
 def (+) : Int -> Int -> Int
 let (+) = elaraPrimitive "+"
 
@@ -24,3 +27,18 @@ let println = elaraPrimitive "println"
 
 def (>>=) : IO a -> (a -> IO b) -> IO b
 let (>>=) = elaraPrimitive ">>="
+
+def stringHead : String -> Char
+let stringHead = elaraPrimitive "stringHead"
+
+def stringTail : String -> String
+let stringTail = elaraPrimitive "stringTail"
+
+def stringCons : Char -> String -> String
+let stringCons = elaraPrimitive "stringCons"
+
+def stringIsEmpty : String -> Bool
+let stringIsEmpty = elaraPrimitive "stringIsEmpty"
+
+def toString : a -> String
+let toString = elaraPrimitive "toString"

--- a/stdlib/prim.elr
+++ b/stdlib/prim.elr
@@ -2,6 +2,8 @@ module Elara.Prim
 
 type Bool = True | False
 
+type List a = Nil | Cons a (List a)
+
 def (-) : Int -> Int -> Int
 let (-) = elaraPrimitive "-"
 

--- a/stdlib/prim.elr
+++ b/stdlib/prim.elr
@@ -1,5 +1,7 @@
 module Elara.Prim
 
+type Bool = True | False
+
 def (-) : Int -> Int -> Int
 let (-) = elaraPrimitive "-"
 

--- a/stdlib/prim.elr
+++ b/stdlib/prim.elr
@@ -4,8 +4,14 @@ type Bool = True | False
 
 type List a = Nil | Cons a (List a)
 
+def (+) : Int -> Int -> Int
+let (+) = elaraPrimitive "+"
+
+def negate : Int -> Int
+let negate = elaraPrimitive "negate"
+
 def (-) : Int -> Int -> Int
-let (-) = elaraPrimitive "-"
+let (-) x y = x + (negate y)
 
 def (==) : a -> a -> Bool
 let (==) = elaraPrimitive "=="

--- a/stdlib/string.elr
+++ b/stdlib/string.elr
@@ -1,0 +1,8 @@
+module String
+import Elara.Prim
+def (++) : String -> String -> String
+let (++) s1 s2 = 
+    if stringIsEmpty s1 then s2
+    else if stringIsEmpty s2 then s1
+    else match (stringHead s1) with
+        c -> stringCons c (stringTail s1 ++ s2)

--- a/stdlib/tuple.elr
+++ b/stdlib/tuple.elr
@@ -1,0 +1,5 @@
+module Tuple
+
+import Elara.Prim
+
+let fst (Tuple2 a b) = a

--- a/test/Boilerplate.hs
+++ b/test/Boilerplate.hs
@@ -27,7 +27,7 @@ import Control.Exception (throwIO)
 import Elara.Data.Pretty (AnsiStyle)
 import Elara.Error
 import Elara.Logging
-import Elara.Prim (primModuleName)
+import Elara.Prim (boolName, mkPrimQual, primModuleName)
 import Elara.TypeInfer.Environment
 import Elara.TypeInfer.Type
 import Hedgehog.Internal.Property (failDiff, failWith)
@@ -118,15 +118,16 @@ fakeOperatorTable =
 
 fakeTypeEnvironment :: TypeEnvironment loc
 fakeTypeEnvironment =
-    emptyTypeEnvironment
-        & addType (TermVarKey (qualifiedTest $ OperatorVarName "+")) (Lifted (Function (Scalar ScalarInt) (Function (Scalar ScalarInt) (Scalar ScalarInt))))
-        & addType (TermVarKey (qualifiedTest $ OperatorVarName "-")) (Lifted (Function (Scalar ScalarInt) (Function (Scalar ScalarInt) (Scalar ScalarInt))))
-        & addType (TermVarKey (qualifiedTest $ OperatorVarName "*")) (Lifted (Function (Scalar ScalarInt) (Function (Scalar ScalarInt) (Scalar ScalarInt))))
-        & addType (TermVarKey (qualifiedTest $ OperatorVarName "/")) (Lifted (Function (Scalar ScalarInt) (Function (Scalar ScalarInt) (Scalar ScalarInt))))
-        & addType (TermVarKey (qualifiedTest $ OperatorVarName "|>")) (Lifted (Function (Scalar ScalarInt) (Function (Scalar ScalarInt) (Scalar ScalarInt))))
-        & addType (TermVarKey (qualifiedTest $ OperatorVarName "==")) (Lifted (Function (Scalar ScalarInt) (Function (Scalar ScalarInt) (Scalar ScalarBool))))
-        & addType (DataConKey (Qualified "True" primModuleName)) (Lifted (Scalar ScalarBool))
-        & addType (DataConKey (Qualified "False" primModuleName)) (Lifted (Scalar ScalarBool))
+    let scalarBool = TypeConstructor (mkPrimQual boolName) []
+     in emptyTypeEnvironment
+            & addType (TermVarKey (qualifiedTest $ OperatorVarName "+")) (Lifted (Function (Scalar ScalarInt) (Function (Scalar ScalarInt) (Scalar ScalarInt))))
+            & addType (TermVarKey (qualifiedTest $ OperatorVarName "-")) (Lifted (Function (Scalar ScalarInt) (Function (Scalar ScalarInt) (Scalar ScalarInt))))
+            & addType (TermVarKey (qualifiedTest $ OperatorVarName "*")) (Lifted (Function (Scalar ScalarInt) (Function (Scalar ScalarInt) (Scalar ScalarInt))))
+            & addType (TermVarKey (qualifiedTest $ OperatorVarName "/")) (Lifted (Function (Scalar ScalarInt) (Function (Scalar ScalarInt) (Scalar ScalarInt))))
+            & addType (TermVarKey (qualifiedTest $ OperatorVarName "|>")) (Lifted (Function (Scalar ScalarInt) (Function (Scalar ScalarInt) (Scalar ScalarInt))))
+            & addType (TermVarKey (qualifiedTest $ OperatorVarName "==")) (Lifted (Function (Scalar ScalarInt) (Function (Scalar ScalarInt) scalarBool)))
+            & addType (DataConKey (Qualified "True" primModuleName)) (Lifted (scalarBool))
+            & addType (DataConKey (Qualified "False" primModuleName)) (Lifted (scalarBool))
 
 mkFakeVar :: OpName -> VarRef VarName
 mkFakeVar name = Global (testLocated (qualifiedTest (OperatorVarName name)))

--- a/test/Infer.hs
+++ b/test/Infer.hs
@@ -106,9 +106,10 @@ recursionTests = withoutRetries $ describe "recursion tests" $ do
 ifElseTests :: Spec
 ifElseTests = describe "If Else Type Inference" $ do
     it "infers if else type correctly" $ property $ do
-        expr <- inferFully "if True then 42 else 43"
+        expr <- inferFully "\\x -> if x then 42 else 43"
 
-        expr === Forall [] EmptyConstraint (Scalar ScalarInt)
+        $(ensureExpressionMatches [p|Forall [] _ (Function _ (Scalar ScalarInt)) |]) expr
+        
 
 inferFully exprSrc = do
     let expr = loadShuntedExpr exprSrc

--- a/test/Parse/Patterns.hs
+++ b/test/Parse/Patterns.hs
@@ -22,9 +22,9 @@ spec = describe "Parses patterns correctly" $ do
         let parsePretty s = fmap stripLocation <$> lexAndParse patParser s
         trippingParse expr showPrettyUnannotated parsePretty
 
--- terminalPatterns
--- consPatterns
--- constructorPatterns
+    terminalPatterns
+    consPatterns
+    constructorPatterns
 
 terminalPatterns :: Spec
 terminalPatterns = parallel $ describe "Parses terminal patterns correctly" $ do
@@ -107,6 +107,7 @@ constructorPatterns = describe "Parses constructor parens" $ do
                     [Pattern (VarPattern "one", Nothing), Pattern (VarPattern "two", Nothing)]
                 , Nothing
                 )
+    
 
     it "Parses nested constructor patterns correctly" $ property $ do
         "(TwoArgs (OneArg one) (OneArg two))"
@@ -125,6 +126,16 @@ constructorPatterns = describe "Parses constructor parens" $ do
                             [Pattern (VarPattern "two", Nothing)]
                         , Nothing
                         )
+                    ]
+                , Nothing
+                )
+    it "Parses nested unary constructor patterns correctly" $ property $ do
+        "Tuple2 Nil _"
+            `shouldParsePattern` Pattern
+                ( ConstructorPattern
+                    "Tuple2"
+                    [ Pattern (ConstructorPattern "Nil" [], Nothing)
+                    , Pattern (WildcardPattern, Nothing)
                     ]
                 , Nothing
                 )


### PR DESCRIPTION
This of course also involves lots of other changes lol
- **refactor: :recycle: Tidy up VarRef, removing dead functions and introducing more pattern synonyms**
- **start work on super simple interpreter**
- **format code**
- **fix(to-core): :bug: Fix global recursive bindings not being created as recursive**
- **feat(interpreter): :sparkles: It works! Mostly**
- **fix(core): :bug: Fix/implement 'HasDependencies (CoreModule bind)'**
- **start implementing type inference for custom types**
- **fix(renamer): Now qualifies type names**
- **feat(type-infer): Basic type inference for ADTs**
- **feat(to-core): Add ADT to-core back**
- **better interpreting of constructors**
- **use uni vars rather than skolems when converting types**
- **move Bool to be defined in the language**
- **improve logging and error displaying for ConstraintGeneration**
- **fix(type-infer): :bug: Fix constraint generation for constructor patterns**
- **Fix HasDependencies instance for Typed AST**
- **style(to-core): :loud_sound: Improve debug logging for ToCore**
- **Remove Bool as a magic primitive as it can be entirely user-defined**
- **lists! and options! also interpret the coregraph in topological order**
- **add IO bind to the interpreter (it sucks so bad)**
- **refactor + and - primops**
- **nicer pretty printing for interpreter values**
- **test: :bug: Fix unit test compilation!**
- **tidy up imports**
- **fix(parser): :bug: Fix Nested Constructor Patterns not being correctly parsed**
- **feat(logging): Write logs to a file because they're getting big! And properly use terminal width now**
- **fix(type-infer): :bug: Fix constraint generation for constructor patterns sometimes leaving things unsolved**
- **fix(core): :bug: Fix `exprType` for polymorphic function applications**
- **fix(to-core): :label: Fix ANF Core type mismatch errors**
- **docs(core): :memo: Slightly improve Core.Type documentation**
- **feat(core): :bug: Fix/improve core type checking of patterns**
- **refactor(logging): :loud_sound: Make sure that core dumps _always_ happen even if typechecking fails**
- **style(to-core): :art: Format code and add some debug logging**
- **refactor(core): :recycle: Rename `exprType` to `guesstimateExprType`**
- **traceablefn stuff (broken)**
- **ayy now it works :)**
- **IMPROVE core typecheck but we need to do elaboration! oh dear god**
- **feat(type-infer): :sparkles: Add type applications!**
- **refactor(logging): :loud_sound: Further improve core dump logs on errors**
- **refactor: :loud_sound: Change priority of pretty printing `ValueType`s**
- **feat: :sparkles: Allow certain AST elements to be assigned polytypes**
- **fix(to-core): :bug: Fix order of type variables/foralls when converting data constructors to core**
- **feat(interpreter): :sparkles: Interpreter correctly handles type applications now!**
- **fix(core): :bug: Fix core type checking for some cases**
- **style(interpreter): :loud_sound: Only log the _new_ bindings when interpreting a module**
- **feat(core): :safety_vest: Add a check for pattern matches missing binders in core typecheck**
- **fix(flake): :bug: Update flake.lock and flake.nix for dependency resolution (NO MORE DEPENDENCY HELL)**
- **update!**
- **fix(flake): Tidy up nix and fix various dependency bugs**
- **build: :arrow_up: Fix dependencies in Nix and use GHC 9.12**
- **style(lexer): :pencil2: Fix typo**
- **feat(pattern-matching): Make pattern matching compilation work...**
- **fix(rename): Fix renaming of recursive lets in a block**
- **fix(main): Fix file locked error when dumping certain information**
- **refactor(errors): Make error reporting a bit more flexible**
- **refactor: minor tidy up**
- **refactor(type-check): Improve type checking for non-recursive lets and enhance error reporting**
- **feat: add more error codes**
- **refactor(type-infer): improve debug output**
- **feat(interpreter): add more prim ops**
- **refactor(type-infer): enhance type inference by implementing skolemisation for expected types**
- **refactor(errors): update ReportableError class to improve default error handling**
- **fix: correct information about bool type constructor**
- **feat(pretty): add Pretty CallStack instance**
- **feat(interpreter): make stringCons primitive work**
- **fix: Fix unique implementation having a questionable Eq/Ord Instance**
- **fix(to-core): :bug: Fix recursive lets not being converted to ANF properly**
- **feat(stdlib): General stdlib improvements**
