### PR TITLE
Implement a basic annotation system

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -154,7 +154,7 @@ runElara settings@(CompilerSettings{dumpSettings = DumpSettings{..}, runWith}) =
                                 when dumpParsed $ do
                                     parsed <- for moduleNames $ \m -> do
                                         runErrorOrReport @(WParseErrorBundle _ _) $ Rock.fetch $ Elara.Query.ParsedModule m
-                                    inject $ dumpGraph parsed (\x -> x ^. _Unwrapped % unlocated % field' @"name" % to nameText) ".parsed.elr"
+                                    -- inject $ dumpGraph parsed (\x -> x ^. _Unwrapped % unlocated % field' @"name" % to nameText) ".parsed.elr"
                                     debug "Dumped parsed modules"
 
                                 when dumpDesugared $ do

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -154,7 +154,7 @@ runElara settings@(CompilerSettings{dumpSettings = DumpSettings{..}, runWith}) =
                                 when dumpParsed $ do
                                     parsed <- for moduleNames $ \m -> do
                                         runErrorOrReport @(WParseErrorBundle _ _) $ Rock.fetch $ Elara.Query.ParsedModule m
-                                    -- inject $ dumpGraph parsed (\x -> x ^. _Unwrapped % unlocated % field' @"name" % to nameText) ".parsed.elr"
+                                    inject $ dumpGraph parsed (\x -> x ^. _Unwrapped % unlocated % field' @"name" % to nameText) ".parsed.elr"
                                     debug "Dumped parsed modules"
 
                                 when dumpDesugared $ do

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -8,11 +8,9 @@ module Main (
 where
 
 import Control.Exception as E
-
--- import Elara.CoreToIR
-
 import Effectful (Eff, IOE, inject, runEff, (:>))
 import Effectful.FileSystem (runFileSystem)
+import Elara.AST.Select
 import Elara.Data.Pretty
 import Elara.Data.Pretty.Styles qualified as Style
 import Elara.Data.Unique (
@@ -171,7 +169,7 @@ runElara settings@(CompilerSettings{dumpSettings = DumpSettings{..}, runWith}) =
 
                                 when dumpShunted $ do
                                     shunted <- for moduleNames $ \m -> do
-                                        runErrorOrReport @ShuntError $ Rock.fetch $ Elara.Query.ShuntedModule m
+                                        runErrorOrReport @ShuntError $ Rock.fetch $ Elara.Query.ModuleByName @Shunted m
                                     inject $ dumpGraph shunted (\x -> x ^. _Unwrapped % unlocated % field' @"name" % to nameText) ".shunted.elr"
                                     debug "Dumped shunted modules"
 

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,4 @@
+packages: elara.cabal
+package *
+    profiling: True
+    profiling-detail: late

--- a/docs/src/language/syntax/annotations.md
+++ b/docs/src/language/syntax/annotations.md
@@ -17,8 +17,8 @@ let (++) = ...
 we use annotations to specify the operator's metadata:
 
 ```fs
-@LeftAssociative
-@Fixity(6)
+#leftAssociative
+#fixity 6
 def (++) : String -> String -> String
 ```
 
@@ -27,8 +27,13 @@ def (++) : String -> String -> String
 Annotations themselves can be defined using the `annotation` keyword:
 
 ```fs
-annotation LeftAssociative
-annotation Fixity (precedence : Int)
+annotation targets (target : [AnnotationTarget])
+
+#targets [OperatorDecl]
+annotation leftAssociative
+
+#targets [OperatorDecl]
+annotation fixity (precedence : Int)
 ```
 
 TODO: I think we can extend this system in a lot of ways : for example, compile time metaprogramming, allowing annotations restrict where certain constructs can be used, aspect oriented programming, etc.

--- a/docs/src/language/syntax/annotations.md
+++ b/docs/src/language/syntax/annotations.md
@@ -1,14 +1,15 @@
 # Annotations
 
-Annotations provide a way to attach metadata to various syntactic constructs in Elara. 
+Annotations provide a way to attach metadata to various syntactic constructs in Elara.
 
 ## Syntax
 
-Annotations are always specified using the `@` symbol followed by an annotation name and optional parameters in parentheses. The eventual goal is that an annotation can be applied to any syntactic construct, however this is a work in progress.
+Annotations are always specified using the `#` symbol followed by an annotation name and optional parameters in parentheses. The eventual goal is that an annotation can be applied to any syntactic construct, however this is a work in progress.
 
-## Operator Information
+### Operator Information
 
-When declaring custom operators, eg 
+When declaring custom operators, eg
+
 ```fs
 def (++) : String -> String -> String
 let (++) = ...
@@ -17,23 +18,35 @@ let (++) = ...
 we use annotations to specify the operator's metadata:
 
 ```fs
-#leftAssociative
-#fixity 6
+#LeftAssociative
+#Fixity 6
 def (++) : String -> String -> String
 ```
+## Annotation Arguments
+
+Annotations can also take arguments. For example, the `Fixity` annotation above takes a single integer argument specifying the operator's precedence level.
+
+The syntax for expression arguments is a subset of Elara where every expression must evaluate to a constant value at compile time. Specifically, this permits:
+- Literal values (integers, strings, booleans, etc.)
+- Constructor application where all arguments are constant values
+- Tuples and lists of constant values
+
 
 ## Defining Annotations
 
-Annotations themselves can be defined using the `annotation` keyword:
+Currently, annotations are identical to data types. That is to say, every data type which only accepts constant values can be used as an annotation. For example, we can define an annotation to specify that a function should be memoised:
 
 ```fs
-annotation targets (target : [AnnotationTarget])
+type Memoise = Memoise
+```
 
-#targets [OperatorDecl]
-annotation leftAssociative
+The aforementioned `LeftAssociative` annotation is simply defined as:
 
-#targets [OperatorDecl]
-annotation fixity (precedence : Int)
+```fs
+type Associativity =
+    LeftAssociative
+    | RightAssociative
+    | NonAssociative
 ```
 
 TODO: I think we can extend this system in a lot of ways : for example, compile time metaprogramming, allowing annotations restrict where certain constructs can be used, aspect oriented programming, etc.

--- a/elara.cabal
+++ b/elara.cabal
@@ -78,6 +78,7 @@ library
       Elara.Lexer.Utils
       Elara.Logging
       Elara.Parse
+      Elara.Parse.Annotation
       Elara.Parse.Combinators
       Elara.Parse.Debug
       Elara.Parse.Declaration
@@ -163,7 +164,6 @@ library
     , effectful-plugin
     , effectful-th
     , filepath
-    , generic-deriving
     , generic-optics
     , h2jvm
     , hashable
@@ -226,7 +226,6 @@ executable elara
     , effectful-th
     , elara
     , filepath
-    , generic-deriving
     , generic-optics
     , h2jvm
     , hashable
@@ -315,7 +314,6 @@ test-suite elara-test
     , effectful-th
     , elara
     , filepath
-    , generic-deriving
     , generic-optics
     , h2jvm
     , hashable

--- a/elara.cabal
+++ b/elara.cabal
@@ -32,6 +32,7 @@ library
       Elara.AST.Generic.Pattern
       Elara.AST.Generic.Types
       Elara.AST.Generic.Utils
+      Elara.AST.Introspection
       Elara.AST.Kinded
       Elara.AST.Module
       Elara.AST.Name
@@ -44,6 +45,7 @@ library
       Elara.AST.Typed
       Elara.AST.Unlocated
       Elara.AST.VarRef
+      Elara.ConstExpr
       Elara.Core
       Elara.Core.Analysis
       Elara.Core.ANF
@@ -100,12 +102,14 @@ library
       Elara.Query
       Elara.Query.Common
       Elara.Query.Effects
+      Elara.Query.Errors
       Elara.Query.TH
       Elara.ReadFile
       Elara.Rename
       Elara.Rename.Error
       Elara.Rename.Imports
       Elara.Rules
+      Elara.Rules.Generic
       Elara.SCC
       Elara.SCC.Type
       Elara.Settings

--- a/elara.cabal
+++ b/elara.cabal
@@ -69,6 +69,7 @@ library
       Elara.Error
       Elara.Error.Codes
       Elara.Error.Effect
+      Elara.Error.Internal
       Elara.Interpreter
       Elara.Lexer.Action
       Elara.Lexer.Char
@@ -97,7 +98,9 @@ library
       Elara.Prim.Core
       Elara.Prim.Rename
       Elara.Query
+      Elara.Query.Common
       Elara.Query.Effects
+      Elara.Query.TH
       Elara.ReadFile
       Elara.Rename
       Elara.Rename.Error
@@ -183,6 +186,7 @@ library
     , safe-exceptions
     , some
     , stringsearch
+    , template-haskell
     , terminal-size
     , text-metrics
     , utf8-string
@@ -245,6 +249,7 @@ executable elara
     , safe-exceptions
     , some
     , stringsearch
+    , template-haskell
     , terminal-size
     , text-metrics
     , utf8-string

--- a/elara.cabal
+++ b/elara.cabal
@@ -163,6 +163,7 @@ library
     , effectful-plugin
     , effectful-th
     , filepath
+    , generic-deriving
     , generic-optics
     , h2jvm
     , hashable
@@ -225,6 +226,7 @@ executable elara
     , effectful-th
     , elara
     , filepath
+    , generic-deriving
     , generic-optics
     , h2jvm
     , hashable
@@ -313,6 +315,7 @@ test-suite elara-test
     , effectful-th
     , elara
     , filepath
+    , generic-deriving
     , generic-optics
     , h2jvm
     , hashable

--- a/flake.nix
+++ b/flake.nix
@@ -182,7 +182,6 @@
                     "mtl"
                     "optics"
                     "parser-combinators"
-
                     "pretty-simple"
                     "prettyprinter"
                     "prettyprinter-ansi-terminal"
@@ -191,6 +190,7 @@
                     "safe-exceptions"
                     "some"
                     "stringsearch"
+                    "template-haskell"
                     "terminal-size"
                     "text-metrics"
                     "utf8-string"

--- a/source.elr
+++ b/source.elr
@@ -131,5 +131,7 @@ let json = jsonNull <|> jsonInt <|> jsonString <|> jsonArray <|> jsonObject
 
 
 let main = 
-    println (1 + 1 + 1 + 1 * 2)
+    match runParser json "[{\"a\": 1}, 12345, null, []]" with
+            None -> println "Failed to parse"
+            Some (result, _) -> println (toString result)
 

--- a/source.elr
+++ b/source.elr
@@ -131,8 +131,5 @@ let json = jsonNull <|> jsonInt <|> jsonString <|> jsonArray <|> jsonObject
 
 
 let main = 
-    match runParser json "[{\"a\": 1}, 12345, null, []]" with
-        None -> println "Failed to parse"
-        Some (result, _) -> println (toString result) >>= \_ -> println (1+1)
+    println (1 + 1 + 1 + 1 * 2)
 
-    

--- a/source.elr
+++ b/source.elr
@@ -133,6 +133,6 @@ let json = jsonNull <|> jsonInt <|> jsonString <|> jsonArray <|> jsonObject
 let main = 
     match runParser json "[{\"a\": 1}, 12345, null, []]" with
         None -> println "Failed to parse"
-        Some (result, _) -> println (toString result)
+        Some (result, _) -> println (toString result) >>= \_ -> println (1+1)
 
     

--- a/src/Elara/AST/Desugared.hs
+++ b/src/Elara/AST/Desugared.hs
@@ -83,7 +83,8 @@ type instance Select Alias 'Desugared = DesugaredType
 
 type instance Select ADTParam 'Desugared = DesugaredType
 
-type instance Select (Annotations any) 'Desugared = NoFieldValue
+type instance Select AnnotationName 'Desugared = MaybeQualified TypeName
+type instance Select (Annotations any) 'Desugared = [Annotation Desugared]
 
 -- Selections for 'Type'
 type instance Select ASTTypeVar 'Desugared = LowerAlphaName

--- a/src/Elara/AST/Desugared.hs
+++ b/src/Elara/AST/Desugared.hs
@@ -67,8 +67,6 @@ type instance Select TypeApplication 'Desugared = DesugaredType
 -- Selections for 'Declaration'
 -- type instance Select DeclarationName 'Desugared = Name
 
-type instance Select AnyName 'Desugared = Name
-
 type instance Select (ASTName ForType) 'Desugared = TypeName
 
 type instance Select (ASTName ForExpr) 'Desugared = VarName

--- a/src/Elara/AST/Desugared.hs
+++ b/src/Elara/AST/Desugared.hs
@@ -14,7 +14,7 @@ import Elara.AST.Generic
 import Elara.AST.Generic.Common
 import Elara.AST.Name (LowerAlphaName, MaybeQualified, Name, OpName, TypeName, VarName, VarOrConName)
 import Elara.AST.Region (Located)
-import Elara.AST.Select (LocatedAST (Desugared))
+import Elara.AST.Select (ASTSelector (..), ForSelector (..), LocatedAST (Desugared))
 
 -- Generic location and qualification types
 type instance ASTLocate' 'Desugared = Located
@@ -22,80 +22,81 @@ type instance ASTLocate' 'Desugared = Located
 type instance ASTQual 'Desugared = MaybeQualified
 
 -- Selections for 'Expr'
-type instance Select "ExprType" 'Desugared = Maybe DesugaredType
+type instance Select (ASTType ForExpr) 'Desugared = Maybe DesugaredType
 
-type instance Select "LambdaPattern" 'Desugared = DesugaredPattern
+type instance Select LambdaPattern 'Desugared = DesugaredPattern
 
-type instance Select "LetPattern" 'Desugared = NoFieldValue
+type instance Select LetPattern 'Desugared = NoFieldValue
 
-type instance Select "VarRef" 'Desugared = MaybeQualified VarName
+type instance Select ASTVarRef 'Desugared = MaybeQualified VarName
 
-type instance Select "ConRef" 'Desugared = MaybeQualified TypeName
+type instance Select ConRef 'Desugared = MaybeQualified TypeName
 
-type instance Select "LetParamName" 'Desugared = VarName
+type instance Select LetParamName 'Desugared = VarName
 
-type instance Select "InParens" 'Desugared = DesugaredExpr
+type instance Select InParens 'Desugared = DesugaredExpr
 
-type instance Select "List" 'Desugared = [DesugaredExpr]
+type instance Select List 'Desugared = [DesugaredExpr]
 
-type instance Select "Tuple" 'Desugared = NonEmpty DesugaredExpr
+type instance Select Tuple 'Desugared = NonEmpty DesugaredExpr
 
-type instance Select "BinaryOperator" 'Desugared = (DesugaredBinaryOperator, DesugaredExpr, DesugaredExpr)
+type instance Select ASTBinaryOperator 'Desugared = (DesugaredBinaryOperator, DesugaredExpr, DesugaredExpr)
 
-type instance Select "TypeApplication" 'Desugared = DesugaredType
+type instance Select (ASTType ForValueDecl) 'Desugared = Maybe DesugaredType
 
 -- Selections for 'BinaryOperator'
-type instance Select "SymOp" 'Desugared = MaybeQualified OpName
+type instance Select SymOp 'Desugared = MaybeQualified OpName
 
-type instance Select "Infixed" 'Desugared = Located (MaybeQualified VarOrConName)
+type instance Select Infixed 'Desugared = Located (MaybeQualified VarOrConName)
 
 -- Selections for 'Pattern'
-type instance Select "PatternType" 'Desugared = Maybe DesugaredType
+type instance Select PatternType 'Desugared = Maybe DesugaredType
 
-type instance Select "VarPat" 'Desugared = LowerAlphaName
+type instance Select VarPat 'Desugared = LowerAlphaName
 
-type instance Select "ConPat" 'Desugared = MaybeQualified TypeName
+type instance Select ConPat 'Desugared = MaybeQualified TypeName
 
-type instance Select "ConsPattern" 'Desugared = (DesugaredPattern, DesugaredPattern)
+type instance Select ConsPattern 'Desugared = (DesugaredPattern, DesugaredPattern)
 
-type instance Select "ListPattern" 'Desugared = [DesugaredPattern]
+type instance Select ListPattern 'Desugared = [DesugaredPattern]
 
-type instance Select "TuplePattern" 'Desugared = NonEmpty DesugaredPattern
+type instance Select TuplePattern 'Desugared = NonEmpty DesugaredPattern
 
-type instance Select "TypeApplication" 'Desugared = DesugaredType
+type instance Select TypeApplication 'Desugared = DesugaredType
 
 -- Selections for 'Declaration'
-type instance Select "DeclarationName" 'Desugared = Name
+-- type instance Select DeclarationName 'Desugared = Name
 
-type instance Select "AnyName" 'Desugared = Name
+type instance Select AnyName 'Desugared = Name
 
-type instance Select "TypeName" 'Desugared = TypeName
+type instance Select (ASTName ForType) 'Desugared = TypeName
 
-type instance Select "ValueName" 'Desugared = VarName
+type instance Select (ASTName ForExpr) 'Desugared = VarName
+type instance Select (ASTName ForValueDecl) 'Desugared = VarName
 
 -- Selections for 'DeclarationBody'
-type instance Select "ValuePatterns" 'Desugared = NoFieldValue
+type instance Select (Patterns ForValueDecl) 'Desugared = NoFieldValue
 
-type instance Select "ValueType" 'Desugared = Maybe DesugaredType
+type instance Select ValueTypeDef 'Desugared = DataConCantHappen
 
-type instance Select "ValueTypeDef" 'Desugared = DataConCantHappen
+type instance Select InfixDecl 'Desugared = DataConCantHappen
 
-type instance Select "InfixDecl" 'Desugared = DataConCantHappen
+type instance Select KindAnnotation 'Desugared = NoFieldValue
 
-type instance Select "KindAnnotation" 'Desugared = NoFieldValue
+type instance Select Alias 'Desugared = DesugaredType
 
-type instance Select "Alias" 'Desugared = DesugaredType
+type instance Select ADTParam 'Desugared = DesugaredType
 
-type instance Select "ADTParam" 'Desugared = DesugaredType
+type instance Select (Annotations any) 'Desugared = NoFieldValue
 
 -- Selections for 'Type'
-type instance Select "TypeVar" 'Desugared = LowerAlphaName
+type instance Select ASTTypeVar 'Desugared = LowerAlphaName
 
-type instance Select "TypeKind" 'Desugared = NoFieldValue
+type instance Select TypeKind 'Desugared = NoFieldValue
 
-type instance Select "UserDefinedType" 'Desugared = MaybeQualified TypeName
+type instance Select UserDefinedType 'Desugared = MaybeQualified TypeName
 
-type instance Select "ConstructorName" 'Desugared = TypeName
+type instance Select ConstructorName 'Desugared = TypeName
 
 type DesugaredExpr = Expr 'Desugared
 

--- a/src/Elara/AST/Desugared.hs
+++ b/src/Elara/AST/Desugared.hs
@@ -79,8 +79,6 @@ type instance Select (Patterns ForValueDecl) 'Desugared = NoFieldValue
 
 type instance Select ValueTypeDef 'Desugared = DataConCantHappen
 
-type instance Select InfixDecl 'Desugared = DataConCantHappen
-
 type instance Select KindAnnotation 'Desugared = NoFieldValue
 
 type instance Select Alias 'Desugared = DesugaredType

--- a/src/Elara/AST/Frontend.hs
+++ b/src/Elara/AST/Frontend.hs
@@ -53,7 +53,8 @@ type family SelectFrontend (selector :: ASTSelector) = (v :: Kind.Type) where
     SelectFrontend ADTParam = FrontendType
     SelectFrontend ValueTypeDef = FrontendType
     -- SelectFrontend (Annotations ForExpr) = NoFieldValue
-    SelectFrontend (Annotations x) = NoFieldValue
+    SelectFrontend AnnotationName = MaybeQualified TypeName
+    SelectFrontend (Annotations _) = [Annotation Frontend]
     SelectFrontend KindAnnotation = NoFieldValue
 
 -- Selections for 'Expr'

--- a/src/Elara/AST/Frontend.hs
+++ b/src/Elara/AST/Frontend.hs
@@ -55,9 +55,7 @@ type family SelectFrontend (selector :: ASTSelector) = (v :: Kind.Type) where
     SelectFrontend ValueTypeDef = FrontendType
     -- SelectFrontend (Annotations ForExpr) = NoFieldValue
     SelectFrontend (Annotations x) = NoFieldValue
-    SelectFrontend (Annotations ForType) = NoFieldValue
     SelectFrontend KindAnnotation = NoFieldValue
-    SelectFrontend InfixDecl = InfixDeclaration 'Frontend
 
 -- Selections for 'Expr'
 

--- a/src/Elara/AST/Frontend.hs
+++ b/src/Elara/AST/Frontend.hs
@@ -42,7 +42,6 @@ type family SelectFrontend (selector :: ASTSelector) = (v :: Kind.Type) where
     -- Selections for 'DeclarationBody'
     SelectFrontend (Patterns ForValueDecl) = [FrontendPattern]
     -- Selections for 'Declaration'
-    SelectFrontend AnyName = Name
     SelectFrontend (ASTName ForType) = TypeName
     SelectFrontend (ASTName ForValueDecl) = VarName
     -- Selections for 'Type'

--- a/src/Elara/AST/Frontend.hs
+++ b/src/Elara/AST/Frontend.hs
@@ -1,95 +1,137 @@
+{-# LANGUAGE TypeFamilyDependencies #-}
 -- Since when was there a warning for orphan type families?
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Elara.AST.Frontend where
 
+import Data.Kind qualified as Kind
 import Elara.AST.Generic
 import Elara.AST.Generic.Common
 import Elara.AST.Name (LowerAlphaName, MaybeQualified, Name, OpName, TypeName, VarName, VarOrConName)
 import Elara.AST.Region (Located (..))
-import Elara.AST.Select (LocatedAST (Frontend))
+import Elara.AST.Select (ASTSelector (..), ForSelector (..), LocatedAST (Frontend))
 
 -- Generic location and qualification types
 type instance ASTLocate' 'Frontend = Located
 
 type instance ASTQual 'Frontend = MaybeQualified
 
+type family SelectFrontend (selector :: ASTSelector) = (v :: Kind.Type) where
+    SelectFrontend (ASTType ForValueDecl) = NoFieldValue
+    SelectFrontend (ASTType ForExpr) = Maybe FrontendType
+    SelectFrontend LambdaPattern = [FrontendPattern]
+    SelectFrontend LetPattern = [FrontendPattern]
+    SelectFrontend ASTVarRef = MaybeQualified VarName
+    SelectFrontend ConRef = MaybeQualified TypeName
+    SelectFrontend LetParamName = VarName
+    SelectFrontend InParens = FrontendExpr
+    SelectFrontend List = [FrontendExpr]
+    SelectFrontend Tuple = NonEmpty FrontendExpr
+    SelectFrontend ASTBinaryOperator = (FrontendBinaryOperator, FrontendExpr, FrontendExpr)
+    SelectFrontend TypeApplication = FrontendType
+    -- Selections for 'BinaryOperator'
+    SelectFrontend SymOp = MaybeQualified OpName
+    SelectFrontend Infixed = Located (MaybeQualified VarOrConName)
+    -- Selections for 'Pattern'
+    SelectFrontend PatternType = Maybe FrontendType
+    SelectFrontend VarPat = LowerAlphaName
+    SelectFrontend ConPat = MaybeQualified TypeName
+    SelectFrontend ListPattern = [FrontendPattern]
+    SelectFrontend TuplePattern = NonEmpty FrontendPattern
+    SelectFrontend ConsPattern = (FrontendPattern, FrontendPattern)
+    -- Selections for 'DeclarationBody'
+    SelectFrontend (Patterns ForValueDecl) = [FrontendPattern]
+    -- Selections for 'Declaration'
+    SelectFrontend AnyName = Name
+    SelectFrontend (ASTName ForType) = TypeName
+    SelectFrontend (ASTName ForValueDecl) = VarName
+    -- Selections for 'Type'
+    SelectFrontend ASTTypeVar = LowerAlphaName
+    SelectFrontend TypeKind = NoFieldValue
+    SelectFrontend UserDefinedType = MaybeQualified TypeName
+    SelectFrontend ConstructorName = TypeName
+    SelectFrontend Alias = FrontendType
+    SelectFrontend ADTParam = FrontendType
+    SelectFrontend ValueTypeDef = FrontendType
+    -- SelectFrontend (Annotations ForExpr) = NoFieldValue
+    SelectFrontend (Annotations x) = NoFieldValue
+    SelectFrontend (Annotations ForType) = NoFieldValue
+    SelectFrontend KindAnnotation = NoFieldValue
+    SelectFrontend InfixDecl = InfixDeclaration 'Frontend
+
 -- Selections for 'Expr'
-type instance Select "ExprType" 'Frontend = Maybe FrontendType
 
-type instance Select "LambdaPattern" 'Frontend = [FrontendPattern]
+type instance Select selector 'Frontend = SelectFrontend selector
 
-type instance Select "LetPattern" 'Frontend = [FrontendPattern]
+-- type instance Select LambdaPattern 'Frontend = [FrontendPattern]
 
-type instance Select "VarRef" 'Frontend = MaybeQualified VarName
+-- type instance Select LetPattern 'Frontend = [FrontendPattern]
 
-type instance Select "ConRef" 'Frontend = MaybeQualified TypeName
+-- type instance Select ASTVarRef 'Frontend = MaybeQualified VarName
 
-type instance Select "LetParamName" 'Frontend = VarName
+-- type instance Select ConRef 'Frontend = MaybeQualified TypeName
 
-type instance Select "InParens" 'Frontend = FrontendExpr
+-- type instance Select LetParamName 'Frontend = VarName
 
-type instance Select "List" 'Frontend = [FrontendExpr]
+-- type instance Select InParens 'Frontend = FrontendExpr
 
-type instance Select "Tuple" 'Frontend = NonEmpty FrontendExpr
+-- type instance Select List 'Frontend = [FrontendExpr]
 
-type instance Select "BinaryOperator" 'Frontend = (FrontendBinaryOperator, FrontendExpr, FrontendExpr)
+-- type instance Select Tuple 'Frontend = NonEmpty FrontendExpr
 
-type instance Select "TypeApplication" 'Frontend = FrontendType
+-- type instance Select ASTBinaryOperator 'Frontend = (FrontendBinaryOperator, FrontendExpr, FrontendExpr)
 
--- Selections for 'BinaryOperator'
-type instance Select "SymOp" 'Frontend = MaybeQualified OpName
+-- type instance Select TypeApplication 'Frontend = FrontendType
 
-type instance Select "Infixed" 'Frontend = Located (MaybeQualified VarOrConName)
+-- -- Selections for 'BinaryOperator'
+-- type instance Select SymOp 'Frontend = MaybeQualified OpName
 
--- Selections for 'Pattern'
-type instance Select "PatternType" 'Frontend = Maybe FrontendType
+-- type instance Select Infixed 'Frontend = Located (MaybeQualified VarOrConName)
 
-type instance Select "VarPat" 'Frontend = LowerAlphaName
+-- -- Selections for 'Pattern'
+-- type instance Select PatternType 'Frontend = Maybe FrontendType
+-- type instance Select VarPat 'Frontend = LowerAlphaName
+-- type instance Select ConPat 'Frontend = MaybeQualified TypeName
+-- type instance Select ListPattern 'Frontend = [FrontendPattern]
+-- type instance Select TuplePattern 'Frontend = NonEmpty FrontendPattern
+-- type instance Select ConsPattern 'Frontend = (FrontendPattern, FrontendPattern)
 
-type instance Select "ConPat" 'Frontend = MaybeQualified TypeName
+-- -- Selections for 'DeclarationBody'
+-- type instance Select (Patterns ForValueDecl) 'Frontend = [FrontendPattern]
 
-type instance Select "ListPattern" 'Frontend = [FrontendPattern]
-type instance Select "TuplePattern" 'Frontend = NonEmpty FrontendPattern
+-- type instance Select (ASTType ForExpr) 'Frontend = NoFieldValue
 
-type instance Select "ConsPattern" 'Frontend = (FrontendPattern, FrontendPattern)
+-- type instance Select ValueTypeDef 'Frontend = FrontendType
 
--- Selections for 'DeclarationBody'
-type instance Select "ValuePatterns" 'Frontend = [FrontendPattern]
+-- type instance Select Alias 'Frontend = FrontendType
 
-type instance Select "ValueType" 'Frontend = NoFieldValue
+-- type instance Select ADTParam 'Frontend = FrontendType
 
-type instance Select "ValueTypeDef" 'Frontend = FrontendType
+-- type instance Select (Annotations ForExpr) 'Frontend = NoFieldValue
 
-type instance Select "Alias" 'Frontend = FrontendType
+-- type instance Select (Annotations ForType) 'Frontend = NoFieldValue
 
-type instance Select "ADTParam" 'Frontend = FrontendType
+-- type instance Select KindAnnotation 'Frontend = NoFieldValue
 
-type instance Select "ValueDeclAnnotations" 'Frontend = NoFieldValue
+-- type instance Select InfixDecl 'Frontend = InfixDeclaration 'Frontend
 
-type instance Select "TypeDeclAnnotations" 'Frontend = NoFieldValue
+-- -- Selections for 'Declaration'
+-- -- type instance Select DeclarationName 'Frontend = Name
 
-type instance Select "KindAnnotation" 'Frontend = NoFieldValue
+-- type instance Select AnyName 'Frontend = Name
 
-type instance Select "InfixDecl" 'Frontend = InfixDeclaration 'Frontend
+-- type instance Select (ASTName ForType) 'Frontend = TypeName
 
--- Selections for 'Declaration'
-type instance Select "DeclarationName" 'Frontend = Name
+-- type instance Select (ASTName ForValueDecl) 'Frontend = VarName
 
-type instance Select "AnyName" 'Frontend = Name
+-- -- Selections for 'Type'
+-- type instance Select TypeVar 'Frontend = LowerAlphaName
 
-type instance Select "TypeName" 'Frontend = TypeName
+-- type instance Select TypeKind 'Frontend = NoFieldValue
 
-type instance Select "ValueName" 'Frontend = VarName
+-- type instance Select UserDefinedType 'Frontend = MaybeQualified TypeName
 
--- Selections for 'Type'
-type instance Select "TypeVar" 'Frontend = LowerAlphaName
-
-type instance Select "TypeKind" 'Frontend = NoFieldValue
-
-type instance Select "UserDefinedType" 'Frontend = MaybeQualified TypeName
-
-type instance Select "ConstructorName" 'Frontend = TypeName
+-- type instance Select ConstructorName 'Frontend = TypeName
 
 type FrontendExpr = Expr 'Frontend
 

--- a/src/Elara/AST/Generic/Common.hs
+++ b/src/Elara/AST/Generic/Common.hs
@@ -2,6 +2,7 @@ module Elara.AST.Generic.Common where
 
 import Data.Data
 import Elara.Data.Pretty
+import GHC.TypeError
 
 data DataConCantHappen deriving (Generic, Data, Show, Eq, Ord)
 
@@ -16,5 +17,5 @@ data NoFieldValue = NoFieldValue
     deriving (Generic, Data, Show, Eq, Ord)
 
 instance Pretty NoFieldValue where
-    pretty :: HasCallStack => NoFieldValue -> Doc AnsiStyle
-    pretty _ = error "This instance should never be used"
+    pretty :: NoFieldValue -> Doc AnsiStyle
+    pretty _ = "NoFieldValue"

--- a/src/Elara/AST/Generic/Instances/Pretty.hs
+++ b/src/Elara/AST/Generic/Instances/Pretty.hs
@@ -10,6 +10,7 @@ import Elara.AST.Generic.Types
 import Elara.AST.Generic.Utils
 import Elara.AST.Name
 import Elara.AST.Pretty
+import Elara.AST.Select
 import Elara.AST.StripLocation
 import Elara.Data.Pretty
 import Elara.Data.Pretty.Styles
@@ -18,8 +19,8 @@ import Prelude hiding (group)
 deriving instance Pretty (ASTLocate ast (BinaryOperator' ast)) => Pretty (BinaryOperator ast)
 
 instance
-    ( Pretty (CleanupLocated (ASTLocate' ast (Select "SymOp" ast)))
-    , (Pretty (Select "Infixed" ast))
+    ( Pretty (CleanupLocated (ASTLocate' ast (Select SymOp ast)))
+    , (Pretty (Select Infixed ast))
     ) =>
     Pretty (BinaryOperator' ast)
     where
@@ -28,8 +29,8 @@ instance
 
 instance
     ( Pretty (ASTLocate ast (Type' ast))
-    , ToMaybe (Select "TypeKind" ast) (Maybe typeKind)
-    , typeKind ~ UnwrapMaybe (Select "TypeKind" ast)
+    , ToMaybe (Select TypeKind ast) (Maybe typeKind)
+    , typeKind ~ UnwrapMaybe (Select TypeKind ast)
     , Pretty typeKind
     ) =>
     Pretty (Type ast)
@@ -51,20 +52,20 @@ instance Pretty UnknownPretty where
 
 instance
     ( Pretty (Expr ast)
-    , Pretty (ASTLocate ast (Select "TypeVar" ast))
-    , Pretty (ASTLocate ast (Select "DeclarationName" ast))
-    , Pretty (ASTLocate ast (Select "AnyName" ast))
-    , Pretty (ASTLocate ast (Select "ValueName" ast))
-    , Pretty (ASTLocate ast (Select "TypeName" ast))
+    , Pretty (ASTLocate ast (Select ASTTypeVar ast))
+    , -- , Pretty (ASTLocate ast (Select DeclarationName ast))
+      Pretty (ASTLocate ast (Select AnyName ast))
+    , Pretty (ASTLocate ast (Select (ASTName ForValueDecl) ast))
+    , Pretty (ASTLocate ast (Select (ASTName ForType) ast))
     , Pretty (ASTLocate ast (TypeDeclaration ast))
-    , Pretty (Select "ValueTypeDef" ast)
-    , Pretty (Select "InfixDecl" ast)
+    , Pretty (Select ValueTypeDef ast)
+    , Pretty (Select InfixDecl ast)
     , Pretty valueType
-    , ToMaybe (Select "ValueType" ast) (Maybe valueType)
-    , valueType ~ UnwrapMaybe (Select "ValueType" ast)
+    , ToMaybe (Select (ASTType ForValueDecl) ast) (Maybe valueType)
+    , valueType ~ UnwrapMaybe (Select (ASTType ForValueDecl) ast)
     , Pretty exprType
-    , exprType ~ UnwrapMaybe (Select "ExprType" ast)
-    , ToMaybe (Select "ExprType" ast) (Maybe exprType)
+    , exprType ~ UnwrapMaybe (Select (ASTType ForExpr) ast)
+    , ToMaybe (Select (ASTType ForExpr) ast) (Maybe exprType)
     , RUnlocate (ast :: b)
     ) =>
     Pretty (Declaration' ast)
@@ -95,45 +96,45 @@ instance
         prettyDB (InfixDecl f) = pretty f
 
 instance
-    ( Pretty (Select "Alias" ast)
-    , Pretty (Select "ADTParam" ast)
-    , Pretty (ASTLocate ast (Select "ConstructorName" ast))
+    ( Pretty (Select Alias ast)
+    , Pretty (Select ADTParam ast)
+    , Pretty (ASTLocate ast (Select ConstructorName ast))
     ) =>
     Pretty (TypeDeclaration ast)
     where
     pretty = \case
         ADT c -> prettyADT c
           where
-            prettyADT :: NonEmpty (CleanupLocated (ASTLocate' ast (Select "ConstructorName" ast)), [Select "ADTParam" ast]) -> Doc AnsiStyle
+            prettyADT :: NonEmpty (CleanupLocated (ASTLocate' ast (Select ConstructorName ast)), [Select ADTParam ast]) -> Doc AnsiStyle
             prettyADT = hsep . punctuate "|" . map (\(name, params) -> pretty name <+> hsep (pretty <$> params)) . toList
         Alias a -> pretty a
 
 instance
-    ( exprType ~ UnwrapMaybe (Select "ExprType" ast) -- This constraint fixes ambiguity errors
-    , letPatterns ~ UnwrapList (Select "LetPattern" ast)
-    , lambdaPatterns ~ UnwrapList (Select "LambdaPattern" ast)
-    , Pretty (ASTLocate ast (Select "ConRef" ast))
-    , Pretty (ASTLocate ast (Select "VarRef" ast))
-    , Pretty (Select "TypeApplication" ast)
-    , (Pretty (ASTLocate ast (Select "LetParamName" ast)))
+    ( exprType ~ UnwrapMaybe (Select (ASTType ForExpr) ast) -- This constraint fixes ambiguity errors
+    , letPatterns ~ UnwrapList (Select LetPattern ast)
+    , lambdaPatterns ~ UnwrapList (Select LambdaPattern ast)
+    , Pretty (ASTLocate ast (Select ConRef ast))
+    , Pretty (ASTLocate ast (Select ASTVarRef ast))
+    , Pretty (Select TypeApplication ast)
+    , (Pretty (ASTLocate ast (Select LetParamName ast)))
     , Pretty letPatterns
-    , letPatterns ~ UnwrapList (Select "LetPattern" ast)
-    , (ToList (Select "LetPattern" ast) [letPatterns])
-    , (ToList (Select "List" ast) [Expr ast])
+    , letPatterns ~ UnwrapList (Select LetPattern ast)
+    , (ToList (Select LetPattern ast) [letPatterns])
+    , (ToList (Select List ast) [Expr ast])
     , Pretty lambdaPatterns
-    , lambdaPatterns ~ UnwrapList (Select "LambdaPattern" ast)
-    , (ToList (ASTLocate ast (Select "LambdaPattern" ast)) [lambdaPatterns])
+    , lambdaPatterns ~ UnwrapList (Select LambdaPattern ast)
+    , (ToList (ASTLocate ast (Select LambdaPattern ast)) [lambdaPatterns])
     , (Pretty (ASTLocate ast (BinaryOperator' ast)))
-    , (ToMaybe (Select "ExprType" ast) (Maybe (UnwrapMaybe (Select "ExprType" ast))))
-    , (ToMaybe (Select "PatternType" ast) (Maybe (UnwrapMaybe (Select "PatternType" ast))))
-    , (Pretty (UnwrapMaybe (Select "ExprType" ast)))
-    , (Pretty (UnwrapMaybe (Select "PatternType" ast)))
+    , (ToMaybe (Select (ASTType ForExpr) ast) (Maybe (UnwrapMaybe (Select (ASTType ForExpr) ast))))
+    , (ToMaybe (Select PatternType ast) (Maybe (UnwrapMaybe (Select PatternType ast))))
+    , (Pretty (UnwrapMaybe (Select (ASTType ForExpr) ast)))
+    , (Pretty (UnwrapMaybe (Select PatternType ast)))
     , (Pretty (CleanupLocated (ASTLocate' ast (Pattern' ast))))
     , (StripLocation (ASTLocate ast (Expr' ast)) (Expr' ast))
-    , (Pretty (Select "ExprType" ast))
-    , (DataConAs (Select "BinaryOperator" ast) (BinaryOperator ast, Expr ast, Expr ast))
-    , (DataConAs (Select "InParens" ast) (Expr ast))
-    , DataConAs (Select "Tuple" ast) (NonEmpty (Expr ast))
+    , (Pretty (Select (ASTType ForExpr) ast))
+    , (DataConAs (Select ASTBinaryOperator ast) (BinaryOperator ast, Expr ast, Expr ast))
+    , (DataConAs (Select InParens ast) (Expr ast))
+    , DataConAs (Select Tuple ast) (NonEmpty (Expr ast))
     , RUnlocate ast
     ) =>
     Pretty (Expr ast)
@@ -145,9 +146,9 @@ instance
 
 prettyExpr ::
     forall ast exprType letPatterns lambdaPatterns.
-    ( exprType ~ UnwrapMaybe (Select "ExprType" ast) -- This constraint fixes ambiguity errors
-    , letPatterns ~ UnwrapList (Select "LetPattern" ast)
-    , lambdaPatterns ~ UnwrapList (Select "LambdaPattern" ast)
+    ( exprType ~ UnwrapMaybe (Select (ASTType ForExpr) ast) -- This constraint fixes ambiguity errors
+    , letPatterns ~ UnwrapList (Select LetPattern ast)
+    , lambdaPatterns ~ UnwrapList (Select LambdaPattern ast)
     , (?contextFree :: Bool, ?withType :: Bool)
     , _
     ) =>
@@ -163,28 +164,28 @@ prettyExpr (Expr (e, t)) = group (flatAlt long short)
 
 instance
     forall ast letPatterns lambdaPatterns.
-    ( Pretty (ASTLocate ast (Select "ConRef" ast))
-    , Pretty (ASTLocate ast (Select "VarRef" ast))
-    , Pretty (Select "TypeApplication" ast)
-    , Pretty (ASTLocate ast (Select "LetParamName" ast))
+    ( Pretty (ASTLocate ast (Select ConRef ast))
+    , Pretty (ASTLocate ast (Select ASTVarRef ast))
+    , Pretty (Select TypeApplication ast)
+    , Pretty (ASTLocate ast (Select LetParamName ast))
     , Pretty letPatterns
-    , letPatterns ~ UnwrapList (Select "LetPattern" ast)
-    , ToList (Select "LetPattern" ast) [letPatterns]
-    , ToList (Select "List" ast) [Expr ast]
+    , letPatterns ~ UnwrapList (Select LetPattern ast)
+    , ToList (Select LetPattern ast) [letPatterns]
+    , ToList (Select List ast) [Expr ast]
     , Pretty lambdaPatterns
-    , lambdaPatterns ~ UnwrapList (Select "LambdaPattern" ast)
-    , (ToList (ASTLocate ast (Select "LambdaPattern" ast)) [lambdaPatterns])
+    , lambdaPatterns ~ UnwrapList (Select LambdaPattern ast)
+    , (ToList (ASTLocate ast (Select LambdaPattern ast)) [lambdaPatterns])
     , (Pretty (ASTLocate ast (BinaryOperator' ast)))
-    , (ToMaybe (Select "ExprType" ast) (Maybe (UnwrapMaybe (Select "ExprType" ast))))
-    , (ToMaybe (Select "PatternType" ast) (Maybe (UnwrapMaybe (Select "PatternType" ast))))
-    , (Pretty (UnwrapMaybe (Select "ExprType" ast)))
-    , (Pretty (UnwrapMaybe (Select "PatternType" ast)))
+    , (ToMaybe (Select (ASTType ForExpr) ast) (Maybe (UnwrapMaybe (Select (ASTType ForExpr) ast))))
+    , (ToMaybe (Select PatternType ast) (Maybe (UnwrapMaybe (Select PatternType ast))))
+    , (Pretty (UnwrapMaybe (Select (ASTType ForExpr) ast)))
+    , (Pretty (UnwrapMaybe (Select PatternType ast)))
     , (Pretty (CleanupLocated (ASTLocate' ast (Pattern' ast))))
     , (StripLocation (CleanupLocated (ASTLocate' ast (Expr' ast))) (Expr' ast))
-    , (Pretty (Select "ExprType" ast))
-    , (DataConAs (Select "BinaryOperator" ast) (BinaryOperator ast, Expr ast, Expr ast))
-    , (DataConAs (Select "InParens" ast) (Expr ast))
-    , DataConAs (Select "Tuple" ast) (NonEmpty (Expr ast))
+    , (Pretty (Select (ASTType ForExpr) ast))
+    , (DataConAs (Select ASTBinaryOperator ast) (BinaryOperator ast, Expr ast, Expr ast))
+    , (DataConAs (Select InParens ast) (Expr ast))
+    , DataConAs (Select Tuple ast) (NonEmpty (Expr ast))
     , RUnlocate ast
     ) =>
     Pretty (Expr' ast)
@@ -196,8 +197,8 @@ instance
 
 prettyExpr' ::
     forall ast letPatterns lambdaPatterns.
-    ( lambdaPatterns ~ UnwrapList (Select "LambdaPattern" ast)
-    , letPatterns ~ UnwrapList (Select "LetPattern" ast)
+    ( lambdaPatterns ~ UnwrapList (Select LambdaPattern ast)
+    , letPatterns ~ UnwrapList (Select LetPattern ast)
     , ?contextFree :: Bool
     , ?withType :: Bool
     , _
@@ -213,31 +214,31 @@ prettyExpr' (Var v) = varName (pretty v)
 prettyExpr' (Constructor c) = typeName (pretty c)
 prettyExpr' (Lambda ps e) =
     prettyLambdaExpr
-        (fieldToList @(ASTLocate ast (Select "LambdaPattern" ast)) ps :: [lambdaPatterns])
+        (fieldToList @(ASTLocate ast (Select LambdaPattern ast)) ps :: [lambdaPatterns])
         (prettyExpr e)
 prettyExpr' (FunctionCall e1 e2) = prettyFunctionCallExpr e1 e2 False
 prettyExpr' (TypeApplication e1 e2) = prettyFunctionCall e1 ("@" <> parens (pretty e2))
 prettyExpr' (If e1 e2 e3) = prettyIfExpr (prettyExpr e1) (prettyExpr e2) (prettyExpr e3)
 prettyExpr' (List l) =
-    prettyList (prettyExpr <$> fieldToList @(Select "List" ast) @[Expr ast] l)
+    prettyList (prettyExpr <$> fieldToList @(Select List ast) @[Expr ast] l)
 prettyExpr' (Match e m) = prettyMatchExpr (prettyExpr e) (prettyMatchBranch . second prettyExpr <$> m)
-prettyExpr' (LetIn v p e1 e2) = prettyLetInExpr v (fieldToList @(Select "LetPattern" ast) p :: [letPatterns]) e1 e2
-prettyExpr' (Let v p e) = prettyLetExpr v (fieldToList @(Select "LetPattern" ast) p :: [letPatterns]) e
+prettyExpr' (LetIn v p e1 e2) = prettyLetInExpr v (fieldToList @(Select LetPattern ast) p :: [letPatterns]) e1 e2
+prettyExpr' (Let v p e) = prettyLetExpr v (fieldToList @(Select LetPattern ast) p :: [letPatterns]) e
 prettyExpr' (Block b) = prettyBlockExpr (prettyExpr <$> b)
 prettyExpr' (Tuple t) =
-    let t' = dataConAs @(Select "Tuple" ast) @(NonEmpty (Expr ast)) t
+    let t' = dataConAs @(Select Tuple ast) @(NonEmpty (Expr ast)) t
      in prettyTupleExpr (prettyExpr <$> t')
 prettyExpr' (BinaryOperator b) =
-    let (op, e1, e2) = dataConAs @(Select "BinaryOperator" ast) @(BinaryOperator ast, Expr ast, Expr ast) b
+    let (op, e1, e2) = dataConAs @(Select ASTBinaryOperator ast) @(BinaryOperator ast, Expr ast, Expr ast) b
      in prettyBinaryOperatorExpr e1 op e2
 prettyExpr' (InParens e) =
-    let e' = dataConAs @(Select "InParens" ast) @(Expr ast) e
+    let e' = dataConAs @(Select InParens ast) @(Expr ast) e
      in parens (prettyExpr e')
 
 instance
     ( Pretty a1
-    , ToMaybe (Select "PatternType" ast) (Maybe a1)
-    , a1 ~ UnwrapMaybe (Select "PatternType" ast)
+    , ToMaybe (Select PatternType ast) (Maybe a1)
+    , a1 ~ UnwrapMaybe (Select PatternType ast)
     , (Pretty (CleanupLocated (ASTLocate' ast (Pattern' ast))))
     ) =>
     Pretty (Pattern ast)
@@ -249,14 +250,14 @@ instance
         short = align (pretty p <+> pretty te)
 
 instance
-    ( Pretty (CleanupLocated (ASTLocate' ast (Select "VarPat" ast)))
-    , Pretty (CleanupLocated (ASTLocate' ast (Select "ConPat" ast)))
-    , (ToMaybe (Select "PatternType" ast) (Maybe (UnwrapMaybe (Select "PatternType" ast))))
-    , (Pretty (UnwrapMaybe (Select "PatternType" ast)))
+    ( Pretty (CleanupLocated (ASTLocate' ast (Select VarPat ast)))
+    , Pretty (CleanupLocated (ASTLocate' ast (Select ConPat ast)))
+    , (ToMaybe (Select PatternType ast) (Maybe (UnwrapMaybe (Select PatternType ast))))
+    , (Pretty (UnwrapMaybe (Select PatternType ast)))
     , (Pretty (CleanupLocated (ASTLocate' ast (Pattern' ast))))
-    , DataConAs (Select "ConsPattern" ast) (Pattern ast, Pattern ast)
-    , DataConAs (Select "ListPattern" ast) [Pattern ast]
-    , DataConAs (Select "TuplePattern" ast) (NonEmpty (Pattern ast))
+    , DataConAs (Select ConsPattern ast) (Pattern ast, Pattern ast)
+    , DataConAs (Select ListPattern ast) [Pattern ast]
+    , DataConAs (Select TuplePattern ast) (NonEmpty (Pattern ast))
     ) =>
     Pretty (Pattern' ast)
     where
@@ -269,10 +270,10 @@ prettyPattern ::
     Doc AnsiStyle
 prettyPattern (VarPattern v) = pretty v
 prettyPattern (ConstructorPattern c ps) = prettyConstructorPattern c ps
-prettyPattern (ListPattern l) = prettyList (dataConAs @(Select "ListPattern" ast) @[Pattern ast] l)
-prettyPattern (TuplePattern t) = prettyTupleExpr (pretty <$> dataConAs @(Select "TuplePattern" ast) @(NonEmpty (Pattern ast)) t)
+prettyPattern (ListPattern l) = prettyList (dataConAs @(Select ListPattern ast) @[Pattern ast] l)
+prettyPattern (TuplePattern t) = prettyTupleExpr (pretty <$> dataConAs @(Select TuplePattern ast) @(NonEmpty (Pattern ast)) t)
 prettyPattern (ConsPattern c) = do
-    let (p1, p2) = dataConAs @(Select "ConsPattern" ast) @(Pattern ast, Pattern ast) c
+    let (p1, p2) = dataConAs @(Select ConsPattern ast) @(Pattern ast, Pattern ast) c
     prettyConsPattern p1 p2
 prettyPattern WildcardPattern = "_"
 prettyPattern (IntegerPattern i) = pretty i
@@ -284,10 +285,10 @@ prettyPattern UnitPattern = "()"
 instance
     ( Pretty (ASTLocate ast (Type' ast))
     , Pretty (ASTLocate ast LowerAlphaName)
-    , Pretty (ASTLocate ast (Select "TypeVar" ast))
-    , Pretty (ASTLocate ast (Select "UserDefinedType" ast))
-    , ToMaybe (Select "TypeKind" ast) (Maybe typeKind)
-    , typeKind ~ UnwrapMaybe (Select "TypeKind" ast)
+    , Pretty (ASTLocate ast (Select ASTTypeVar ast))
+    , Pretty (ASTLocate ast (Select UserDefinedType ast))
+    , ToMaybe (Select TypeKind ast) (Maybe typeKind)
+    , typeKind ~ UnwrapMaybe (Select TypeKind ast)
     , Pretty typeKind
     ) =>
     Pretty (Type' ast)
@@ -304,10 +305,10 @@ instance
       where
         prettyFields = hsep . punctuate "," . map (\(name, value) -> pretty name <+> ":" <+> pretty value) . toList
 
-instance (Pretty (ASTLocate ast (Select "AnyName" ast)), RUnlocate ast) => Pretty (ValueDeclAnnotations ast) where
-    pretty (ValueDeclAnnotations v) = braces ("Operator fixity:" <+> maybe "None" pretty v)
+instance (Pretty (ASTLocate ast (Select AnyName ast)), RUnlocate ast) => Pretty (ValueDeclAnnotations ast) where
+    pretty (ValueDeclAnnotations v _) = braces ("Operator fixity:" <+> maybe "None" pretty v)
 
-instance (Pretty (ASTLocate ast (Select "AnyName" ast)), RUnlocate (ast :: b)) => Pretty (InfixDeclaration ast) where
+instance (Pretty (ASTLocate ast (Select AnyName ast)), RUnlocate (ast :: b)) => Pretty (InfixDeclaration ast) where
     pretty (InfixDeclaration name prec assoc) =
         ( case rUnlocate @b @ast assoc of
             LeftAssoc -> "infixl"
@@ -319,8 +320,8 @@ instance (Pretty (ASTLocate ast (Select "AnyName" ast)), RUnlocate (ast :: b)) =
 
 instance
     ( Pretty v
-    , ToMaybe (Select "PatternType" ast) (Maybe pt)
-    , pt ~ UnwrapMaybe (Select "PatternType" ast)
+    , ToMaybe (Select PatternType ast) (Maybe pt)
+    , pt ~ UnwrapMaybe (Select PatternType ast)
     , Pretty pt
     ) =>
     Pretty (TypedLambdaParam v ast)

--- a/src/Elara/AST/Generic/Instances/Pretty.hs
+++ b/src/Elara/AST/Generic/Instances/Pretty.hs
@@ -90,7 +90,7 @@ instance
                             )
              in prettyValueDeclaration n e typeOfE ann
         prettyDB (TypeDeclaration n vars t ann) = prettyTypeDeclaration n vars t ann
-        prettyDB (ValueTypeDef n t) = prettyValueTypeDef n t
+        prettyDB (ValueTypeDef n t _) = prettyValueTypeDef n t
 
 instance
     ( Pretty (Select Alias ast)

--- a/src/Elara/AST/Generic/Instances/Pretty.hs
+++ b/src/Elara/AST/Generic/Instances/Pretty.hs
@@ -54,7 +54,6 @@ instance
     ( Pretty (Expr ast)
     , Pretty (ASTLocate ast (Select ASTTypeVar ast))
     , Pretty (Select (Annotations ForValueDecl) ast)
-    , Pretty (ASTLocate ast (Select AnyName ast))
     , Pretty (ASTLocate ast (Select (ASTName ForValueDecl) ast))
     , Pretty (ASTLocate ast (Select (ASTName ForType) ast))
     , Pretty (ASTLocate ast (TypeDeclaration ast))

--- a/src/Elara/AST/Generic/Instances/Pretty.hs
+++ b/src/Elara/AST/Generic/Instances/Pretty.hs
@@ -335,7 +335,8 @@ instance
         Nothing -> pretty v
 
 deriving instance Pretty (Select (Annotations ForValueDecl) ast) => Pretty (ValueDeclAnnotations ast)
-
+instance (Pretty (Select (Annotations ForTypeDecl) ast), Pretty (Select (Annotations ForType) ast), Pretty (Select KindAnnotation ast)) => Pretty (TypeDeclAnnotations ast)
 deriving instance Pretty (Expr ast) => Pretty (AnnotationArg ast)
+
 instance (Pretty (ASTLocate ast (Select AnnotationName ast)), Pretty (AnnotationArg ast)) => Pretty (Annotation ast) where
     pretty (Annotation name args) = punctuation "#" <> pretty name <> hsep (pretty <$> args)

--- a/src/Elara/AST/Generic/Instances/Pretty.hs
+++ b/src/Elara/AST/Generic/Instances/Pretty.hs
@@ -53,13 +53,12 @@ instance Pretty UnknownPretty where
 instance
     ( Pretty (Expr ast)
     , Pretty (ASTLocate ast (Select ASTTypeVar ast))
-    , -- , Pretty (ASTLocate ast (Select DeclarationName ast))
-      Pretty (ASTLocate ast (Select AnyName ast))
+    , Pretty (Select (Annotations ForValueDecl) ast)
+    , Pretty (ASTLocate ast (Select AnyName ast))
     , Pretty (ASTLocate ast (Select (ASTName ForValueDecl) ast))
     , Pretty (ASTLocate ast (Select (ASTName ForType) ast))
     , Pretty (ASTLocate ast (TypeDeclaration ast))
     , Pretty (Select ValueTypeDef ast)
-    , Pretty (Select InfixDecl ast)
     , Pretty valueType
     , ToMaybe (Select (ASTType ForValueDecl) ast) (Maybe valueType)
     , valueType ~ UnwrapMaybe (Select (ASTType ForValueDecl) ast)
@@ -93,7 +92,6 @@ instance
              in prettyValueDeclaration n e typeOfE ann
         prettyDB (TypeDeclaration n vars t ann) = prettyTypeDeclaration n vars t ann
         prettyDB (ValueTypeDef n t) = prettyValueTypeDef n t
-        prettyDB (InfixDecl f) = pretty f
 
 instance
     ( Pretty (Select Alias ast)
@@ -305,19 +303,6 @@ instance
       where
         prettyFields = hsep . punctuate "," . map (\(name, value) -> pretty name <+> ":" <+> pretty value) . toList
 
-instance (Pretty (ASTLocate ast (Select AnyName ast)), RUnlocate ast) => Pretty (ValueDeclAnnotations ast) where
-    pretty (ValueDeclAnnotations v _) = braces ("Operator fixity:" <+> maybe "None" pretty v)
-
-instance (Pretty (ASTLocate ast (Select AnyName ast)), RUnlocate (ast :: b)) => Pretty (InfixDeclaration ast) where
-    pretty (InfixDeclaration name prec assoc) =
-        ( case rUnlocate @b @ast assoc of
-            LeftAssoc -> "infixl"
-            RightAssoc -> "infixr"
-            NonAssoc -> "infix"
-        )
-            <+> pretty @Int (rUnlocate @b @ast prec)
-            <+> pretty name
-
 instance
     ( Pretty v
     , ToMaybe (Select PatternType ast) (Maybe pt)
@@ -329,3 +314,5 @@ instance
     pretty (TypedLambdaParam (v, t)) = case toMaybe t of
         Just t' -> pretty v <+> ":" <+> pretty @pt t'
         Nothing -> pretty v
+
+deriving instance Pretty (Select (Annotations ForValueDecl) ast) => Pretty (ValueDeclAnnotations ast)

--- a/src/Elara/AST/Generic/Instances/Pretty.hs
+++ b/src/Elara/AST/Generic/Instances/Pretty.hs
@@ -90,7 +90,7 @@ instance
                             )
              in prettyValueDeclaration n e typeOfE ann
         prettyDB (TypeDeclaration n vars t ann) = prettyTypeDeclaration n vars t ann
-        prettyDB (ValueTypeDef n t _) = prettyValueTypeDef n t
+        prettyDB (ValueTypeDef n t ann) = prettyValueTypeDef n t (Just ann)
 
 instance
     ( Pretty (Select Alias ast)

--- a/src/Elara/AST/Generic/Instances/Pretty.hs
+++ b/src/Elara/AST/Generic/Instances/Pretty.hs
@@ -315,3 +315,7 @@ instance
         Nothing -> pretty v
 
 deriving instance Pretty (Select (Annotations ForValueDecl) ast) => Pretty (ValueDeclAnnotations ast)
+
+deriving instance Pretty (Expr ast) => Pretty (AnnotationArg ast)
+instance (Pretty (ASTLocate ast (Select AnnotationName ast)), Pretty (AnnotationArg ast)) => Pretty (Annotation ast) where
+    pretty (Annotation name args) = punctuation "#" <> pretty name <> hsep (pretty <$> args)

--- a/src/Elara/AST/Generic/Instances/Simple.hs
+++ b/src/Elara/AST/Generic/Instances/Simple.hs
@@ -152,7 +152,6 @@ deriving instance
 
 deriving instance
     ( Eq (DeclarationBody' ast)
-    , Ord (Select InfixDecl ast)
     , Ord (Select ValueTypeDef ast)
     , Ord (Select (Patterns ForValueDecl) ast)
     , Ord (Select (ASTType ForValueDecl) ast)
@@ -167,8 +166,7 @@ deriving instance
     Ord (DeclarationBody' ast)
 
 deriving instance
-    ( Eq (Select InfixDecl ast)
-    , Eq (Select ValueTypeDef ast)
+    ( Eq (Select ValueTypeDef ast)
     , Eq (Select (Patterns ForValueDecl) ast)
     , Eq (Select (ASTType ForValueDecl) ast)
     , Eq (Expr ast)
@@ -180,28 +178,6 @@ deriving instance
     , Eq (ASTLocate ast (TypeDeclaration ast))
     ) =>
     Eq (DeclarationBody' ast)
-
-deriving instance (Eq (InfixDeclaration ast), Eq (Select KindAnnotation ast), Eq (Select (Annotations ForTypeDecl) ast)) => Eq (TypeDeclAnnotations ast)
-
-deriving instance
-    ( Eq (ASTLocate ast (Select AnyName ast))
-    , Eq (ASTLocate ast Int)
-    , Eq (ASTLocate ast AssociativityType)
-    ) =>
-    Eq (InfixDeclaration ast)
-
-deriving instance (Ord (InfixDeclaration ast), Ord (Select KindAnnotation ast), Ord (Select (Annotations ForTypeDecl) ast)) => Ord (TypeDeclAnnotations ast)
-
-deriving instance
-    ( Ord (ASTLocate ast (Select AnyName ast))
-    , Ord (ASTLocate ast Int)
-    , Ord (ASTLocate ast AssociativityType)
-    ) =>
-    Ord (InfixDeclaration ast)
-
-deriving instance (Eq (InfixDeclaration ast), Eq (Select (Annotations ForValueDecl) ast)) => Eq (ValueDeclAnnotations ast)
-
-deriving instance (Ord (InfixDeclaration ast), Ord (Select (Annotations ForValueDecl) ast)) => Ord (ValueDeclAnnotations ast)
 
 deriving instance
     ( Ord (Select Alias ast)
@@ -217,6 +193,11 @@ deriving instance
     , Eq (ASTLocate ast (Select ConstructorName ast))
     ) =>
     Eq (TypeDeclaration ast)
+
+deriving instance Eq (Select (Annotations ForValueDecl) ast) => Eq (ValueDeclAnnotations ast)
+deriving instance (Eq (Select KindAnnotation ast), Eq (Select (Annotations ForTypeDecl) ast)) => Eq (TypeDeclAnnotations ast)
+deriving instance Ord (Select (Annotations ForValueDecl) ast) => Ord (ValueDeclAnnotations ast)
+deriving instance (Ord (Select KindAnnotation ast), Ord (Select (Annotations ForTypeDecl) ast)) => Ord (TypeDeclAnnotations ast)
 
 -- Show instances
 
@@ -283,14 +264,12 @@ deriving instance
     ( (Show (Select ValueTypeDef ast))
     , (Show (Select (Patterns ForValueDecl) ast))
     , (Show (Select (ASTType ForExpr) ast))
-    , Show (Select InfixDecl ast)
     , Show (Select (ASTType ForValueDecl) ast)
     , Show (ASTLocate ast (Select ASTTypeVar ast))
     , Show (ASTLocate ast (Select (ASTName ForType) ast))
     , Show (ASTLocate ast (Select (ASTName ForValueDecl) ast))
     , Show (ASTLocate ast (Expr' ast))
     , Show (ASTLocate ast Int)
-    , Show (ASTLocate ast AssociativityType)
     , Show (ASTLocate ast (TypeDeclaration ast))
     , Show (TypeDeclAnnotations ast)
     , Show (ValueDeclAnnotations ast)
@@ -299,12 +278,6 @@ deriving instance
 
 deriving instance Show (ASTLocate ast (DeclarationBody' ast)) => Show (DeclarationBody ast)
 
-deriving instance (Show (ASTLocate ast (Select AnyName ast)), Show (ASTLocate ast Int), Show (ASTLocate ast AssociativityType)) => Show (InfixDeclaration ast)
-
-deriving instance (Show (InfixDeclaration ast), Show (Select KindAnnotation ast), Show (Select (Annotations ForTypeDecl) ast)) => Show (TypeDeclAnnotations ast)
-
-deriving instance (Show (InfixDeclaration ast), Show (Select (Annotations ForValueDecl) ast)) => Show (ValueDeclAnnotations ast)
-
 deriving instance
     ( Show (ASTLocate ast (Select ConstructorName ast))
     , Show (Type ast)
@@ -312,6 +285,9 @@ deriving instance
     , Show (Select ADTParam ast)
     ) =>
     Show (TypeDeclaration ast)
+
+deriving instance Show (Select (Annotations ForValueDecl) ast) => Show (ValueDeclAnnotations ast)
+deriving instance (Show (Select KindAnnotation ast), Show (Select (Annotations ForTypeDecl) ast)) => Show (TypeDeclAnnotations ast)
 
 -- Data instances
 

--- a/src/Elara/AST/Generic/Instances/Simple.hs
+++ b/src/Elara/AST/Generic/Instances/Simple.hs
@@ -199,6 +199,12 @@ deriving instance (Eq (Select KindAnnotation ast), Eq (Select (Annotations ForTy
 deriving instance Ord (Select (Annotations ForValueDecl) ast) => Ord (ValueDeclAnnotations ast)
 deriving instance (Ord (Select KindAnnotation ast), Ord (Select (Annotations ForTypeDecl) ast)) => Ord (TypeDeclAnnotations ast)
 
+deriving instance Eq (Expr ast) => Eq (AnnotationArg ast)
+deriving instance (Eq (ASTLocate ast (Select AnnotationName ast)), Eq (AnnotationArg ast)) => Eq (Annotation ast)
+
+deriving instance Ord (Expr ast) => Ord (AnnotationArg ast)
+deriving instance (Ord (ASTLocate ast (Select AnnotationName ast)), Ord (AnnotationArg ast)) => Ord (Annotation ast)
+
 -- Show instances
 
 deriving instance

--- a/src/Elara/AST/Generic/Instances/Simple.hs
+++ b/src/Elara/AST/Generic/Instances/Simple.hs
@@ -289,6 +289,9 @@ deriving instance
 deriving instance Show (Select (Annotations ForValueDecl) ast) => Show (ValueDeclAnnotations ast)
 deriving instance (Show (Select KindAnnotation ast), Show (Select (Annotations ForTypeDecl) ast)) => Show (TypeDeclAnnotations ast)
 
+deriving instance (Show (AnnotationArg ast), Show (ASTLocate ast (Select AnnotationName ast))) => Show (Annotation ast)
+deriving instance Show (Expr ast) => Show (AnnotationArg ast)
+
 -- Data instances
 
 deriving instance

--- a/src/Elara/AST/Generic/Instances/Simple.hs
+++ b/src/Elara/AST/Generic/Instances/Simple.hs
@@ -9,29 +9,30 @@ import Data.Kind qualified as Kind
 import Elara.AST.Generic.Types
 import Elara.AST.Name
 import Elara.AST.Region
+import Elara.AST.Select (ASTSelector (..), ForSelector (..))
 
 type ForAllExpr :: (Kind.Type -> Kind.Constraint) -> ast -> Kind.Constraint
 type ForAllExpr c ast =
     ( c (Expr ast)
-    , c (ASTLocate ast (Select "VarRef" ast))
-    , c (ASTLocate ast (Select "LambdaPattern" ast))
-    , c (ASTLocate ast (Select "ConRef" ast))
-    , c (ASTLocate ast (Select "LetParamName" ast))
-    , c (Select "InParens" ast)
+    , c (ASTLocate ast (Select ASTVarRef ast))
+    , c (ASTLocate ast (Select LambdaPattern ast))
+    , c (ASTLocate ast (Select ConRef ast))
+    , c (ASTLocate ast (Select LetParamName ast))
+    , c (Select InParens ast)
     )
 
 -- Eq/Ord instances
 
 deriving instance
-    ( (Eq (Select "LetPattern" ast))
+    ( (Eq (Select LetPattern ast))
     , ForAllExpr Eq ast
     , (Eq (ASTLocate ast (BinaryOperator' ast)))
-    , Eq (Select "ExprType" ast)
-    , Eq (Select "PatternType" ast)
-    , Eq (Select "BinaryOperator" ast)
-    , Eq (Select "List" ast)
-    , Eq (Select "Tuple" ast)
-    , Eq (Select "TypeApplication" ast)
+    , Eq (Select (ASTType ForExpr) ast)
+    , Eq (Select PatternType ast)
+    , Eq (Select ASTBinaryOperator ast)
+    , Eq (Select List ast)
+    , Eq (Select Tuple ast)
+    , Eq (Select TypeApplication ast)
     , Eq (ASTLocate ast (Expr' ast))
     , Eq (ASTLocate ast (Pattern' ast))
     , Eq (Type ast)
@@ -39,76 +40,76 @@ deriving instance
     Eq (Expr' ast)
 
 deriving instance
-    ( Ord (Select "LetPattern" ast)
+    ( Ord (Select LetPattern ast)
     , ForAllExpr Ord ast
     , Ord (ASTLocate ast (BinaryOperator' ast))
-    , Ord (Select "ExprType" ast)
-    , Ord (Select "PatternType" ast)
-    , Ord (Select "BinaryOperator" ast)
-    , Ord (Select "List" ast)
-    , Ord (Select "Tuple" ast)
-    , Ord (Select "TypeApplication" ast)
+    , Ord (Select (ASTType ForExpr) ast)
+    , Ord (Select PatternType ast)
+    , Ord (Select ASTBinaryOperator ast)
+    , Ord (Select List ast)
+    , Ord (Select Tuple ast)
+    , Ord (Select TypeApplication ast)
     , Ord (ASTLocate ast (Expr' ast))
     , Ord (ASTLocate ast (Pattern' ast))
     , Ord (Type ast)
     ) =>
     Ord (Expr' ast)
 
-deriving instance (Eq (ASTLocate ast (Expr' ast)), Eq (Select "ExprType" ast)) => Eq (Expr ast)
+deriving instance (Eq (ASTLocate ast (Expr' ast)), Eq (Select (ASTType ForExpr) ast)) => Eq (Expr ast)
 
-deriving instance (Ord (ASTLocate ast (Expr' ast)), Ord (Select "ExprType" ast)) => Ord (Expr ast)
+deriving instance (Ord (ASTLocate ast (Expr' ast)), Ord (Select (ASTType ForExpr) ast)) => Ord (Expr ast)
 
 deriving instance
-    ( Eq (ASTLocate ast (Select "VarPat" ast))
-    , Eq (ASTLocate ast (Select "ConPat" ast))
-    , Eq (Select "PatternType" ast)
-    , Eq (Select "ConsPattern" ast)
-    , Eq (Select "ListPattern" ast)
-    , Eq (Select "TuplePattern" ast)
+    ( Eq (ASTLocate ast (Select VarPat ast))
+    , Eq (ASTLocate ast (Select ConPat ast))
+    , Eq (Select PatternType ast)
+    , Eq (Select ConsPattern ast)
+    , Eq (Select ListPattern ast)
+    , Eq (Select TuplePattern ast)
     , Eq (ASTLocate ast (Pattern' ast))
     ) =>
     Eq (Pattern' ast)
 
 deriving instance
-    ( Ord (ASTLocate ast (Select "VarPat" ast))
-    , Ord (ASTLocate ast (Select "ConPat" ast))
-    , Ord (Select "PatternType" ast)
-    , Ord (Select "ConsPattern" ast)
-    , Ord (Select "ListPattern" ast)
-    , Ord (Select "TuplePattern" ast)
+    ( Ord (ASTLocate ast (Select VarPat ast))
+    , Ord (ASTLocate ast (Select ConPat ast))
+    , Ord (Select PatternType ast)
+    , Ord (Select ConsPattern ast)
+    , Ord (Select ListPattern ast)
+    , Ord (Select TuplePattern ast)
     , Ord (ASTLocate ast (Pattern' ast))
     ) =>
     Ord (Pattern' ast)
 
-deriving instance (Eq (ASTLocate ast (Pattern' ast)), Eq (Select "PatternType" ast)) => Eq (Pattern ast)
+deriving instance (Eq (ASTLocate ast (Pattern' ast)), Eq (Select PatternType ast)) => Eq (Pattern ast)
 
-deriving instance (Ord (ASTLocate ast (Pattern' ast)), Ord (Select "PatternType" ast)) => Ord (Pattern ast)
+deriving instance (Ord (ASTLocate ast (Pattern' ast)), Ord (Select PatternType ast)) => Ord (Pattern ast)
 
 deriving instance
-    ( Eq (ASTLocate ast (Select "TypeVar" ast))
-    , Eq (ASTLocate ast (Select "UserDefinedType" ast))
+    ( Eq (ASTLocate ast (Select ASTTypeVar ast))
+    , Eq (ASTLocate ast (Select UserDefinedType ast))
     , Eq (ASTLocate ast (Type' ast))
     , Eq (ASTLocate ast LowerAlphaName)
     , Eq (Type ast)
     ) =>
     Eq (Type' ast)
 
-deriving instance (Eq (ASTLocate ast (Type' ast)), Eq (Select "TypeKind" ast)) => Eq (Type ast)
+deriving instance (Eq (ASTLocate ast (Type' ast)), Eq (Select TypeKind ast)) => Eq (Type ast)
 
 deriving instance
-    ( Ord (ASTLocate ast (Select "TypeVar" ast))
-    , Ord (ASTLocate ast (Select "UserDefinedType" ast))
+    ( Ord (ASTLocate ast (Select ASTTypeVar ast))
+    , Ord (ASTLocate ast (Select UserDefinedType ast))
     , Ord (ASTLocate ast (Type' ast))
     , Ord (ASTLocate ast LowerAlphaName)
     , Ord (Type ast)
     ) =>
     Ord (Type' ast)
 
-deriving instance (Ord (ASTLocate ast (Type' ast)), Ord (Select "TypeKind" ast)) => Ord (Type ast)
+deriving instance (Ord (ASTLocate ast (Type' ast)), Ord (Select TypeKind ast)) => Ord (Type ast)
 
 deriving instance
-    ( Eq (ASTLocate ast (Select "SymOp" ast))
-    , Eq (Select "Infixed" ast)
+    ( Eq (ASTLocate ast (Select SymOp ast))
+    , Eq (Select Infixed ast)
     ) =>
     Eq (BinaryOperator' ast)
 
@@ -118,8 +119,8 @@ deriving instance Eq (ASTLocate ast (Declaration' ast)) => Eq (Declaration ast)
 
 deriving instance
     ( Eq (DeclarationBody ast)
-    , Eq (ASTLocate ast (Select "DeclarationName" ast))
-    , Eq (ASTLocate ast ModuleName)
+    , -- , Eq (ASTLocate ast (Select DeclarationName ast))
+      Eq (ASTLocate ast ModuleName)
     ) =>
     Eq (Declaration' ast)
 
@@ -128,16 +129,16 @@ deriving instance Eq (ASTLocate ast (DeclarationBody' ast)) => Eq (DeclarationBo
 deriving instance Ord (ASTLocate ast (BinaryOperator' ast)) => Ord (BinaryOperator ast)
 
 deriving instance
-    ( Ord (ASTLocate ast (Select "SymOp" ast))
-    , Ord (Select "Infixed" ast)
+    ( Ord (ASTLocate ast (Select SymOp ast))
+    , Ord (Select Infixed ast)
     ) =>
     Ord (BinaryOperator' ast)
 
 deriving instance
     ( Eq (Declaration' ast)
     , Ord (DeclarationBody ast)
-    , Ord (ASTLocate ast (Select "DeclarationName" ast))
-    , Ord (ASTLocate ast ModuleName)
+    , -- , Ord (ASTLocate ast (Select DeclarationName ast))
+      Ord (ASTLocate ast ModuleName)
     ) =>
     Ord (Declaration' ast)
 
@@ -151,83 +152,83 @@ deriving instance
 
 deriving instance
     ( Eq (DeclarationBody' ast)
-    , Ord (Select "InfixDecl" ast)
-    , Ord (Select "ValueTypeDef" ast)
-    , Ord (Select "ValuePatterns" ast)
-    , Ord (Select "ValueType" ast)
+    , Ord (Select InfixDecl ast)
+    , Ord (Select ValueTypeDef ast)
+    , Ord (Select (Patterns ForValueDecl) ast)
+    , Ord (Select (ASTType ForValueDecl) ast)
     , Ord (Expr ast)
     , Ord (ValueDeclAnnotations ast)
     , Ord (TypeDeclAnnotations ast)
-    , Ord (ASTLocate ast (Select "TypeVar" ast))
-    , Ord (ASTLocate ast (Select "TypeName" ast))
-    , Ord (ASTLocate ast (Select "ValueName" ast))
+    , Ord (ASTLocate ast (Select ASTTypeVar ast))
+    , Ord (ASTLocate ast (Select (ASTName ForType) ast))
+    , Ord (ASTLocate ast (Select (ASTName ForValueDecl) ast))
     , Ord (ASTLocate ast (TypeDeclaration ast))
     ) =>
     Ord (DeclarationBody' ast)
 
 deriving instance
-    ( Eq (Select "InfixDecl" ast)
-    , Eq (Select "ValueTypeDef" ast)
-    , Eq (Select "ValuePatterns" ast)
-    , Eq (Select "ValueType" ast)
+    ( Eq (Select InfixDecl ast)
+    , Eq (Select ValueTypeDef ast)
+    , Eq (Select (Patterns ForValueDecl) ast)
+    , Eq (Select (ASTType ForValueDecl) ast)
     , Eq (Expr ast)
     , Eq (ValueDeclAnnotations ast)
     , Eq (TypeDeclAnnotations ast)
-    , Eq (ASTLocate ast (Select "TypeVar" ast))
-    , Eq (ASTLocate ast (Select "TypeName" ast))
-    , Eq (ASTLocate ast (Select "ValueName" ast))
+    , Eq (ASTLocate ast (Select ASTTypeVar ast))
+    , Eq (ASTLocate ast (Select (ASTName ForType) ast))
+    , Eq (ASTLocate ast (Select (ASTName ForValueDecl) ast))
     , Eq (ASTLocate ast (TypeDeclaration ast))
     ) =>
     Eq (DeclarationBody' ast)
 
-deriving instance (Eq (InfixDeclaration ast), Eq (Select "KindAnnotation" ast)) => Eq (TypeDeclAnnotations ast)
+deriving instance (Eq (InfixDeclaration ast), Eq (Select KindAnnotation ast), Eq (Select (Annotations ForTypeDecl) ast)) => Eq (TypeDeclAnnotations ast)
 
 deriving instance
-    ( Eq (ASTLocate ast (Select "AnyName" ast))
+    ( Eq (ASTLocate ast (Select AnyName ast))
     , Eq (ASTLocate ast Int)
     , Eq (ASTLocate ast AssociativityType)
     ) =>
     Eq (InfixDeclaration ast)
 
-deriving instance (Ord (InfixDeclaration ast), Ord (Select "KindAnnotation" ast)) => Ord (TypeDeclAnnotations ast)
+deriving instance (Ord (InfixDeclaration ast), Ord (Select KindAnnotation ast), Ord (Select (Annotations ForTypeDecl) ast)) => Ord (TypeDeclAnnotations ast)
 
 deriving instance
-    ( Ord (ASTLocate ast (Select "AnyName" ast))
+    ( Ord (ASTLocate ast (Select AnyName ast))
     , Ord (ASTLocate ast Int)
     , Ord (ASTLocate ast AssociativityType)
     ) =>
     Ord (InfixDeclaration ast)
 
-deriving instance Eq (InfixDeclaration ast) => Eq (ValueDeclAnnotations ast)
+deriving instance (Eq (InfixDeclaration ast), Eq (Select (Annotations ForValueDecl) ast)) => Eq (ValueDeclAnnotations ast)
 
-deriving instance Ord (InfixDeclaration ast) => Ord (ValueDeclAnnotations ast)
+deriving instance (Ord (InfixDeclaration ast), Ord (Select (Annotations ForValueDecl) ast)) => Ord (ValueDeclAnnotations ast)
 
 deriving instance
-    ( Ord (Select "Alias" ast)
+    ( Ord (Select Alias ast)
     , Eq (TypeDeclaration ast)
-    , Ord (Select "ADTParam" ast)
-    , Ord (ASTLocate ast (Select "ConstructorName" ast))
+    , Ord (Select ADTParam ast)
+    , Ord (ASTLocate ast (Select ConstructorName ast))
     ) =>
     Ord (TypeDeclaration ast)
 
 deriving instance
-    ( Eq (Select "Alias" ast)
-    , Eq (Select "ADTParam" ast)
-    , Eq (ASTLocate ast (Select "ConstructorName" ast))
+    ( Eq (Select Alias ast)
+    , Eq (Select ADTParam ast)
+    , Eq (ASTLocate ast (Select ConstructorName ast))
     ) =>
     Eq (TypeDeclaration ast)
 
 -- Show instances
 
 deriving instance
-    ( Show (Select "LetPattern" ast)
-    , Show (Select "TypeApplication" ast)
+    ( Show (Select LetPattern ast)
+    , Show (Select TypeApplication ast)
     , Show (ASTLocate ast (BinaryOperator' ast))
-    , Show (Select "ExprType" ast)
-    , Show (Select "PatternType" ast)
-    , Show (Select "BinaryOperator" ast)
-    , Show (Select "List" ast)
-    , Show (Select "Tuple" ast)
+    , Show (Select (ASTType ForExpr) ast)
+    , Show (Select PatternType ast)
+    , Show (Select ASTBinaryOperator ast)
+    , Show (Select List ast)
+    , Show (Select Tuple ast)
     , Show (ASTLocate ast (Expr' ast))
     , Show (ASTLocate ast (Pattern' ast))
     , Show (Type ast)
@@ -235,35 +236,35 @@ deriving instance
     ) =>
     Show (Expr' ast)
 
-deriving instance (Show (ASTLocate ast (Expr' ast)), Show (Select "ExprType" ast)) => Show (Expr ast)
+deriving instance (Show (ASTLocate ast (Expr' ast)), Show (Select (ASTType ForExpr) ast)) => Show (Expr ast)
 
 deriving instance
-    ( Show (ASTLocate ast (Select "VarPat" ast))
-    , Show (ASTLocate ast (Select "ConPat" ast))
-    , Show (Select "PatternType" ast)
-    , Show (Select "ConsPattern" ast)
-    , Show (Select "ListPattern" ast)
-    , Show (Select "TuplePattern" ast)
+    ( Show (ASTLocate ast (Select VarPat ast))
+    , Show (ASTLocate ast (Select ConPat ast))
+    , Show (Select PatternType ast)
+    , Show (Select ConsPattern ast)
+    , Show (Select ListPattern ast)
+    , Show (Select TuplePattern ast)
     , Show (ASTLocate ast (Pattern' ast))
     ) =>
     Show (Pattern' ast)
 
-deriving instance (Show (ASTLocate ast (Pattern' ast)), Show (Select "PatternType" ast)) => Show (Pattern ast)
+deriving instance (Show (ASTLocate ast (Pattern' ast)), Show (Select PatternType ast)) => Show (Pattern ast)
 
 deriving instance
-    ( Show (ASTLocate ast (Select "TypeVar" ast))
-    , Show (ASTLocate ast (Select "UserDefinedType" ast))
+    ( Show (ASTLocate ast (Select ASTTypeVar ast))
+    , Show (ASTLocate ast (Select UserDefinedType ast))
     , Show (ASTLocate ast (Type' ast))
     , Show (ASTLocate ast LowerAlphaName)
     , Show (Type ast)
     ) =>
     Show (Type' ast)
 
-deriving instance (Show (ASTLocate ast (Type' ast)), Show (Select "TypeKind" ast)) => Show (Type ast)
+deriving instance (Show (ASTLocate ast (Type' ast)), Show (Select TypeKind ast)) => Show (Type ast)
 
 deriving instance
-    ( Show (ASTLocate ast (Select "SymOp" ast))
-    , Show (Select "Infixed" ast)
+    ( Show (ASTLocate ast (Select SymOp ast))
+    , Show (Select Infixed ast)
     ) =>
     Show (BinaryOperator' ast)
 
@@ -271,22 +272,22 @@ deriving instance Show (ASTLocate ast (BinaryOperator' ast)) => Show (BinaryOper
 
 deriving instance
     ( Show (DeclarationBody ast)
-    , Show (ASTLocate ast (Select "DeclarationName" ast))
-    , Show (ASTLocate ast ModuleName)
+    , -- , Show (ASTLocate ast (Select (DeclarationName) ast))
+      Show (ASTLocate ast ModuleName)
     ) =>
     Show (Declaration' ast)
 
 deriving instance Show (ASTLocate ast (Declaration' ast)) => Show (Declaration ast)
 
 deriving instance
-    ( (Show (Select "ValueTypeDef" ast))
-    , (Show (Select "ValuePatterns" ast))
-    , (Show (Select "ValueType" ast))
-    , Show (Select "InfixDecl" ast)
-    , Show (Select "ExprType" ast)
-    , Show (ASTLocate ast (Select "TypeVar" ast))
-    , Show (ASTLocate ast (Select "TypeName" ast))
-    , Show (ASTLocate ast (Select "ValueName" ast))
+    ( (Show (Select ValueTypeDef ast))
+    , (Show (Select (Patterns ForValueDecl) ast))
+    , (Show (Select (ASTType ForExpr) ast))
+    , Show (Select InfixDecl ast)
+    , Show (Select (ASTType ForValueDecl) ast)
+    , Show (ASTLocate ast (Select ASTTypeVar ast))
+    , Show (ASTLocate ast (Select (ASTName ForType) ast))
+    , Show (ASTLocate ast (Select (ASTName ForValueDecl) ast))
     , Show (ASTLocate ast (Expr' ast))
     , Show (ASTLocate ast Int)
     , Show (ASTLocate ast AssociativityType)
@@ -298,17 +299,17 @@ deriving instance
 
 deriving instance Show (ASTLocate ast (DeclarationBody' ast)) => Show (DeclarationBody ast)
 
-deriving instance (Show (ASTLocate ast (Select "AnyName" ast)), Show (ASTLocate ast Int), Show (ASTLocate ast AssociativityType)) => Show (InfixDeclaration ast)
+deriving instance (Show (ASTLocate ast (Select AnyName ast)), Show (ASTLocate ast Int), Show (ASTLocate ast AssociativityType)) => Show (InfixDeclaration ast)
 
-deriving instance (Show (InfixDeclaration ast), Show (Select "KindAnnotation" ast)) => Show (TypeDeclAnnotations ast)
+deriving instance (Show (InfixDeclaration ast), Show (Select KindAnnotation ast), Show (Select (Annotations ForTypeDecl) ast)) => Show (TypeDeclAnnotations ast)
 
-deriving instance Show (InfixDeclaration ast) => Show (ValueDeclAnnotations ast)
+deriving instance (Show (InfixDeclaration ast), Show (Select (Annotations ForValueDecl) ast)) => Show (ValueDeclAnnotations ast)
 
 deriving instance
-    ( Show (ASTLocate ast (Select "ConstructorName" ast))
+    ( Show (ASTLocate ast (Select ConstructorName ast))
     , Show (Type ast)
-    , Show (Select "Alias" ast)
-    , Show (Select "ADTParam" ast)
+    , Show (Select Alias ast)
+    , Show (Select ADTParam ast)
     ) =>
     Show (TypeDeclaration ast)
 
@@ -317,7 +318,7 @@ deriving instance
 deriving instance
     forall a (ast :: a).
     ( Data (ASTLocate ast (Pattern' ast))
-    , Data (Select "PatternType" ast)
+    , Data (Select PatternType ast)
     , Typeable ast
     , Typeable a
     ) =>
@@ -328,18 +329,18 @@ deriving instance
     ( Typeable a
     , Typeable ast
     , (Data (Pattern ast))
-    , (Data (ASTLocate ast (Select "VarPat" ast)))
-    , (Data (ASTLocate ast (Select "ConPat" ast)))
-    , (Data (Select "ConsPattern" ast))
-    , (Data (Select "ListPattern" ast))
-    , (Data (Select "TuplePattern" ast))
+    , (Data (ASTLocate ast (Select VarPat ast)))
+    , (Data (ASTLocate ast (Select ConPat ast)))
+    , (Data (Select ConsPattern ast))
+    , (Data (Select ListPattern ast))
+    , (Data (Select TuplePattern ast))
     ) =>
     Data (Pattern' ast)
 
 deriving instance
     forall a (ast :: a).
     ( Data (ASTLocate ast (Expr' ast))
-    , Data (Select "ExprType" ast)
+    , Data (Select (ASTType ForExpr) ast)
     , Typeable ast
     , Typeable a
     ) =>
@@ -348,14 +349,14 @@ deriving instance
 deriving instance
     forall a (ast :: a).
     ( Data (ASTLocate ast (Expr' ast))
-    , Data (Select "LetPattern" ast)
-    , Data (Select "PatternType" ast)
-    , Data (Select "BinaryOperator" ast)
-    , Data (Select "List" ast)
-    , Data (Select "Tuple" ast)
-    , Data (Select "ExprType" ast)
+    , Data (Select LetPattern ast)
+    , Data (Select PatternType ast)
+    , Data (Select ASTBinaryOperator ast)
+    , Data (Select List ast)
+    , Data (Select Tuple ast)
+    , Data (Select (ASTType ForExpr) ast)
     , ForAllExpr Data ast
-    , Data (Select "TypeApplication" ast)
+    , Data (Select TypeApplication ast)
     , Data (ASTLocate ast (Pattern' ast))
     , Typeable ast
     , Typeable a
@@ -365,9 +366,9 @@ deriving instance
 deriving instance
     forall a (ast :: a).
     ( Data (ASTLocate ast (Type' ast))
-    , Data (Select "TypeVar" ast)
-    , Data (Select "UserDefinedType" ast)
-    , Data (Select "TypeKind" ast)
+    , Data (Select ASTTypeVar ast)
+    , Data (Select UserDefinedType ast)
+    , Data (Select TypeKind ast)
     , Typeable ast
     , Typeable a
     ) =>
@@ -376,12 +377,12 @@ deriving instance
 deriving instance
     forall a (ast :: a).
     ( Data (ASTLocate ast (Type' ast))
-    , Data (ASTLocate ast (Select "TypeVar" ast))
-    , Data (Select "TypeVar" ast)
-    , Data (ASTLocate ast (Select "UserDefinedType" ast))
+    , Data (ASTLocate ast (Select ASTTypeVar ast))
+    , Data (Select ASTTypeVar ast)
+    , Data (ASTLocate ast (Select UserDefinedType ast))
     , Data (ASTLocate ast LowerAlphaName)
-    , Data (Select "UserDefinedType" ast)
-    , Data (Select "TypeKind" ast)
+    , Data (Select UserDefinedType ast)
+    , Data (Select TypeKind ast)
     , Typeable ast
     , Typeable a
     ) =>
@@ -395,8 +396,8 @@ instance ASTLocate' ast ~ Located => HasSourceRegion (Pattern ast) where
 instance ASTLocate' ast ~ Located => HasSourceRegion (Expr ast) where
     sourceRegion = _Unwrapped % _1 % sourceRegion
 
-deriving instance (Eq v, Eq (Select "PatternType" ast)) => Eq (TypedLambdaParam v ast)
+deriving instance (Eq v, Eq (Select PatternType ast)) => Eq (TypedLambdaParam v ast)
 
-deriving instance (Ord v, Ord (Select "PatternType" ast)) => Ord (TypedLambdaParam v ast)
+deriving instance (Ord v, Ord (Select PatternType ast)) => Ord (TypedLambdaParam v ast)
 
-deriving instance (Show v, Show (Select "PatternType" ast)) => Show (TypedLambdaParam v ast)
+deriving instance (Show v, Show (Select PatternType ast)) => Show (TypedLambdaParam v ast)

--- a/src/Elara/AST/Generic/Instances/StripLocation.hs
+++ b/src/Elara/AST/Generic/Instances/StripLocation.hs
@@ -14,32 +14,32 @@ instance
     forall (ast1 :: LocatedAST) (ast2 :: UnlocatedAST).
     ( ASTLocate' ast1 ~ Located
     , ASTLocate' ast2 ~ Unlocated
-    , (StripLocation (Select "LambdaPattern" ast1) (Select "LambdaPattern" ast2))
-    , (StripLocation (Select "LetPattern" ast1) (Select "LetPattern" ast2))
-    , StripLocation (Select "TypeApplication" ast1) (Select "TypeApplication" ast2)
-    , (ApplyAsFunctorish (Select "ExprType" ast1) (Select "ExprType" ast2) (Type ast1) (Type ast2))
-    , (ApplyAsFunctorish (Select "PatternType" ast1) (Select "PatternType" ast2) (Type ast1) (Type ast2))
-    , ApplyAsFunctorish (Select "ConsPattern" ast1) (Select "ConsPattern" ast2) (Pattern ast1) (Pattern ast2)
-    , ApplyAsFunctorish (Select "ListPattern" ast1) (Select "ListPattern" ast2) (Pattern ast1) (Pattern ast2)
-    , (StripLocation (Select "Infixed" ast1) (Select "Infixed" ast2))
-    , (StripLocation (CleanupLocated (Located (Select "SymOp" ast1))) (Select "SymOp" ast2))
-    , (StripLocation (CleanupLocated (Located (Select "TypeVar" ast1))) (Select "TypeVar" ast2))
-    , (StripLocation (CleanupLocated (Located (Select "VarRef" ast1))) (Select "VarRef" ast2))
-    , (StripLocation (CleanupLocated (Located (Select "VarPat" ast1))) (Select "VarPat" ast2))
-    , (StripLocation (CleanupLocated (Located (Select "ConPat" ast1))) (Select "ConPat" ast2))
-    , (StripLocation (CleanupLocated (Located (Select "ConRef" ast1))) (Select "ConRef" ast2))
-    , (StripLocation (CleanupLocated (Located (Select "LambdaPattern" ast1))) (Select "LambdaPattern" ast1))
-    , (StripLocation (CleanupLocated (Located (Select "LetParamName" ast1))) (Select "LetParamName" ast2))
-    , (StripLocation (CleanupLocated (Located (Select "UserDefinedType" ast1))) (Select "UserDefinedType" ast2))
-    , (DataConAs (Select "BinaryOperator" ast1) (BinaryOperator ast1, Expr ast1, Expr ast1))
-    , (DataConAs (Select "BinaryOperator" ast2) (BinaryOperator ast2, Expr ast2, Expr ast2))
-    , (DataConAs (Select "InParens" ast1) (Expr ast1))
-    , (DataConAs (Select "List" ast1) [Expr ast1])
-    , (DataConAs (Select "List" ast2) [Expr ast2])
-    , (DataConAs (Select "InParens" ast2) (Expr ast2))
-    , StripLocation (Select "TypeKind" ast1) (Select "TypeKind" ast2)
-    , DataConAs (Select "Tuple" ast1) (NonEmpty (Expr ast1))
-    , DataConAs (Select "Tuple" ast2) (NonEmpty (Expr ast2))
+    , (StripLocation (Select LambdaPattern ast1) (Select LambdaPattern ast2))
+    , (StripLocation (Select LetPattern ast1) (Select LetPattern ast2))
+    , StripLocation (Select TypeApplication ast1) (Select TypeApplication ast2)
+    , (ApplyAsFunctorish (Select (ASTType ForExpr) ast1) (Select (ASTType ForExpr) ast2) (Type ast1) (Type ast2))
+    , (ApplyAsFunctorish (Select PatternType ast1) (Select PatternType ast2) (Type ast1) (Type ast2))
+    , ApplyAsFunctorish (Select ConsPattern ast1) (Select ConsPattern ast2) (Pattern ast1) (Pattern ast2)
+    , ApplyAsFunctorish (Select ListPattern ast1) (Select ListPattern ast2) (Pattern ast1) (Pattern ast2)
+    , (StripLocation (Select Infixed ast1) (Select Infixed ast2))
+    , (StripLocation (CleanupLocated (Located (Select SymOp ast1))) (Select SymOp ast2))
+    , (StripLocation (CleanupLocated (Located (Select ASTTypeVar ast1))) (Select ASTTypeVar ast2))
+    , (StripLocation (CleanupLocated (Located (Select ASTVarRef ast1))) (Select ASTVarRef ast2))
+    , (StripLocation (CleanupLocated (Located (Select VarPat ast1))) (Select VarPat ast2))
+    , (StripLocation (CleanupLocated (Located (Select ConPat ast1))) (Select ConPat ast2))
+    , (StripLocation (CleanupLocated (Located (Select ConRef ast1))) (Select ConRef ast2))
+    , (StripLocation (CleanupLocated (Located (Select LambdaPattern ast1))) (Select LambdaPattern ast1))
+    , (StripLocation (CleanupLocated (Located (Select LetParamName ast1))) (Select LetParamName ast2))
+    , (StripLocation (CleanupLocated (Located (Select UserDefinedType ast1))) (Select UserDefinedType ast2))
+    , (DataConAs (Select ASTBinaryOperator ast1) (BinaryOperator ast1, Expr ast1, Expr ast1))
+    , (DataConAs (Select ASTBinaryOperator ast2) (BinaryOperator ast2, Expr ast2, Expr ast2))
+    , (DataConAs (Select InParens ast1) (Expr ast1))
+    , (DataConAs (Select List ast1) [Expr ast1])
+    , (DataConAs (Select List ast2) [Expr ast2])
+    , (DataConAs (Select InParens ast2) (Expr ast2))
+    , StripLocation (Select TypeKind ast1) (Select TypeKind ast2)
+    , DataConAs (Select Tuple ast1) (NonEmpty (Expr ast1))
+    , DataConAs (Select Tuple ast2) (NonEmpty (Expr ast2))
     ) =>
     StripLocation (Expr ast1) (Expr ast2)
     where
@@ -49,11 +49,11 @@ stripExprLocation ::
     forall (ast1 :: LocatedAST) (ast2 :: UnlocatedAST).
     ( ASTLocate' ast1 ~ Located
     , ASTLocate' ast2 ~ Unlocated
-    , StripLocation (Select "LambdaPattern" ast1) (Select "LambdaPattern" ast2)
-    , StripLocation (Select "TypeApplication" ast1) (Select "TypeApplication" ast2)
-    , StripLocation (Select "LetPattern" ast1) (Select "LetPattern" ast2)
-    , ApplyAsFunctorish (Select "ExprType" ast1) (Select "ExprType" ast2) (Type ast1) (Type ast2)
-    , DataConAs (Select "BinaryOperator" ast1) (BinaryOperator ast1, Expr ast1, Expr ast1)
+    , StripLocation (Select LambdaPattern ast1) (Select LambdaPattern ast2)
+    , StripLocation (Select TypeApplication ast1) (Select TypeApplication ast2)
+    , StripLocation (Select LetPattern ast1) (Select LetPattern ast2)
+    , ApplyAsFunctorish (Select (ASTType ForExpr) ast1) (Select (ASTType ForExpr) ast2) (Type ast1) (Type ast2)
+    , DataConAs (Select ASTBinaryOperator ast1) (BinaryOperator ast1, Expr ast1, Expr ast1)
     , _
     ) =>
     Expr ast1 ->
@@ -62,7 +62,7 @@ stripExprLocation (Expr (e :: ASTLocate ast1 (Expr' ast1), t)) =
     let e' = fmapUnlocated @LocatedAST @ast1 stripExprLocation' e
      in Expr
             ( stripLocation e'
-            , applyAsFunctorish @(Select "ExprType" ast1) @(Select "ExprType" ast2) @(Type ast1) @(Type ast2)
+            , applyAsFunctorish @(Select (ASTType ForExpr) ast1) @(Select (ASTType ForExpr) ast2) @(Type ast1) @(Type ast2)
                 stripTypeLocation
                 t
             )
@@ -78,40 +78,40 @@ stripExprLocation (Expr (e :: ASTLocate ast1 (Expr' ast1), t)) =
     stripExprLocation' (Lambda ps e) =
         let ps' = stripLocation ps
             ps'' =
-                stripLocation @(Select "LambdaPattern" ast1) @(Select "LambdaPattern" ast2)
+                stripLocation @(Select LambdaPattern ast1) @(Select LambdaPattern ast2)
                     ps'
          in Lambda ps'' (stripExprLocation e)
     stripExprLocation' (FunctionCall e1 e2) = FunctionCall (stripExprLocation e1) (stripExprLocation e2)
     stripExprLocation' (TypeApplication e1 t1) =
         let t1' = stripLocation t1
-            t1'' = stripLocation @(Select "TypeApplication" ast1) @(Select "TypeApplication" ast2) t1'
+            t1'' = stripLocation @(Select TypeApplication ast1) @(Select TypeApplication ast2) t1'
          in TypeApplication
                 (stripExprLocation e1)
                 t1''
     stripExprLocation' (If e1 e2 e3) = If (stripExprLocation e1) (stripExprLocation e2) (stripExprLocation e3)
     stripExprLocation' (BinaryOperator b) =
-        let (op, e1, e2) = dataConAs @(Select "BinaryOperator" ast1) @(BinaryOperator ast1, Expr ast1, Expr ast1) b
+        let (op, e1, e2) = dataConAs @(Select ASTBinaryOperator ast1) @(BinaryOperator ast1, Expr ast1, Expr ast1) b
          in BinaryOperator $ asDataCon (stripBinaryOperatorLocation @ast1 @ast2 op, stripExprLocation e1, stripExprLocation e2)
     stripExprLocation' (List l) =
-        let l' = dataConAs @(Select "List" ast1) @[Expr ast1] l
+        let l' = dataConAs @(Select List ast1) @[Expr ast1] l
          in List $ asDataCon (stripExprLocation <$> l')
     stripExprLocation' (Match e m) = Match (stripExprLocation e) (bimapF stripPatternLocation stripExprLocation m)
     stripExprLocation' (LetIn v p e1 e2) =
-        let p' = stripLocation @(Select "LetPattern" ast1) @(Select "LetPattern" ast2) p
+        let p' = stripLocation @(Select LetPattern ast1) @(Select LetPattern ast2) p
          in LetIn
                 (stripLocation v)
                 p'
                 (stripExprLocation e1)
                 (stripExprLocation e2)
     stripExprLocation' (Let v p e) =
-        let p' = stripLocation @(Select "LetPattern" ast1) @(Select "LetPattern" ast2) p
+        let p' = stripLocation @(Select LetPattern ast1) @(Select LetPattern ast2) p
          in Let (stripLocation v) p' (stripExprLocation e)
     stripExprLocation' (Block b) = Block (stripExprLocation <$> b)
     stripExprLocation' (Tuple t) =
-        let t' = dataConAs @(Select "Tuple" ast1) @(NonEmpty (Expr ast1)) t
+        let t' = dataConAs @(Select Tuple ast1) @(NonEmpty (Expr ast1)) t
          in Tuple $ asDataCon (stripExprLocation <$> t')
     stripExprLocation' (InParens e) =
-        let e' = dataConAs @(Select "InParens" ast1) @(Expr ast1) e
+        let e' = dataConAs @(Select InParens ast1) @(Expr ast1) e
          in InParens $ asDataCon (stripExprLocation e')
 
 instance
@@ -119,35 +119,35 @@ instance
     ( ASTLocate' ast1 ~ Located
     , ASTLocate' ast2 ~ Unlocated
     , ( ApplyAsFunctorish
-            (Select "PatternType" ast1)
-            (Select "PatternType" ast2)
+            (Select PatternType ast1)
+            (Select PatternType ast2)
             (Type ast1)
             (Type ast2)
       )
     , ApplyAsFunctorish
-        (Select "ConsPattern" ast1)
-        (Select "ConsPattern" ast2)
+        (Select ConsPattern ast1)
+        (Select ConsPattern ast2)
         (Pattern ast1)
         (Pattern ast2)
     , ApplyAsFunctorish
-        (Select "ListPattern" ast1)
-        (Select "ListPattern" ast2)
+        (Select ListPattern ast1)
+        (Select ListPattern ast2)
         (Pattern ast1)
         (Pattern ast2)
     , ( StripLocation
-            (CleanupLocated (Located (Select "TypeVar" ast1)))
-            (Select "TypeVar" ast2)
+            (CleanupLocated (Located (Select ASTTypeVar ast1)))
+            (Select ASTTypeVar ast2)
       )
     , ( StripLocation
-            (CleanupLocated (Located (Select "VarPat" ast1)))
-            (Select "VarPat" ast2)
+            (CleanupLocated (Located (Select VarPat ast1)))
+            (Select VarPat ast2)
       )
     , ( StripLocation
-            (CleanupLocated (Located (Select "ConPat" ast1)))
-            (Select "ConPat" ast2)
+            (CleanupLocated (Located (Select ConPat ast1)))
+            (Select ConPat ast2)
       )
-    , (StripLocation (CleanupLocated (Located (Select "UserDefinedType" ast1))) (Select "UserDefinedType" ast2))
-    , StripLocation (Select "TypeKind" ast1) (Select "TypeKind" ast2)
+    , (StripLocation (CleanupLocated (Located (Select UserDefinedType ast1))) (Select UserDefinedType ast2))
+    , StripLocation (Select TypeKind ast1) (Select TypeKind ast2)
     ) =>
     StripLocation (Pattern ast1) (Pattern ast2)
     where
@@ -165,7 +165,7 @@ stripPatternLocation (Pattern (p :: ASTLocate ast1 (Pattern' ast1), t)) =
     let p' = fmapUnlocated @LocatedAST @ast1 stripPatternLocation' p
      in Pattern
             ( stripLocation p'
-            , applyAsFunctorish @(Select "PatternType" ast1) @(Select "PatternType" ast2) @(Type ast1) @(Type ast2) stripTypeLocation t
+            , applyAsFunctorish @(Select PatternType ast1) @(Select PatternType ast2) @(Type ast1) @(Type ast2) stripTypeLocation t
             )
   where
     stripPatternLocation' :: Pattern' ast1 -> Pattern' ast2
@@ -173,8 +173,8 @@ stripPatternLocation (Pattern (p :: ASTLocate ast1 (Pattern' ast1), t)) =
     stripPatternLocation' (ConstructorPattern c ps) = ConstructorPattern (stripLocation c) (stripPatternLocation <$> ps)
     stripPatternLocation' (ListPattern l) =
         ListPattern
-            ( applyAsFunctorish @(Select "ListPattern" ast1)
-                @(Select "ListPattern" ast2)
+            ( applyAsFunctorish @(Select ListPattern ast1)
+                @(Select ListPattern ast2)
                 @(Pattern ast1)
                 @(Pattern ast2)
                 stripPatternLocation
@@ -182,8 +182,8 @@ stripPatternLocation (Pattern (p :: ASTLocate ast1 (Pattern' ast1), t)) =
             )
     stripPatternLocation' (ConsPattern p1) =
         ConsPattern
-            ( applyAsFunctorish @(Select "ConsPattern" ast1)
-                @(Select "ConsPattern" ast2)
+            ( applyAsFunctorish @(Select ConsPattern ast1)
+                @(Select ConsPattern ast2)
                 @(Pattern ast1)
                 @(Pattern ast2)
                 stripPatternLocation
@@ -200,10 +200,10 @@ instance
     forall (ast1 :: LocatedAST) (ast2 :: UnlocatedAST).
     ( ASTLocate' ast1 ~ Located
     , ASTLocate' ast2 ~ Unlocated
-    , (StripLocation (Select "Infixed" ast1) (Select "Infixed" ast2))
+    , (StripLocation (Select Infixed ast1) (Select Infixed ast2))
     , ( StripLocation
-            (CleanupLocated (Located (Select "SymOp" ast1)))
-            (Select "SymOp" ast2)
+            (CleanupLocated (Located (Select SymOp ast1)))
+            (Select SymOp ast2)
       )
     ) =>
     StripLocation (BinaryOperator ast1) (BinaryOperator ast2)
@@ -231,9 +231,9 @@ instance
     forall (ast1 :: LocatedAST) (ast2 :: UnlocatedAST).
     ( (ASTLocate' ast1 ~ Located)
     , ASTLocate' ast2 ~ Unlocated
-    , StripLocation (CleanupLocated (Located (Select "TypeVar" ast1))) (Select "TypeVar" ast2)
-    , StripLocation (CleanupLocated (Located (Select "UserDefinedType" ast1))) (Select "UserDefinedType" ast2)
-    , StripLocation (Select "TypeKind" ast1) (Select "TypeKind" ast2)
+    , StripLocation (CleanupLocated (Located (Select ASTTypeVar ast1))) (Select ASTTypeVar ast2)
+    , StripLocation (CleanupLocated (Located (Select UserDefinedType ast1))) (Select UserDefinedType ast2)
+    , StripLocation (Select TypeKind ast1) (Select TypeKind ast2)
     ) =>
     StripLocation (Type ast1) (Type ast2)
     where
@@ -243,9 +243,9 @@ stripTypeLocation ::
     forall (ast1 :: LocatedAST) (ast2 :: UnlocatedAST).
     ( (ASTLocate' ast1 ~ Located)
     , ASTLocate' ast2 ~ Unlocated
-    , StripLocation (CleanupLocated (Located (Select "TypeVar" ast1))) (Select "TypeVar" ast2)
-    , StripLocation (CleanupLocated (Located (Select "UserDefinedType" ast1))) (Select "UserDefinedType" ast2)
-    , StripLocation (Select "TypeKind" ast1) (Select "TypeKind" ast2)
+    , StripLocation (CleanupLocated (Located (Select ASTTypeVar ast1))) (Select ASTTypeVar ast2)
+    , StripLocation (CleanupLocated (Located (Select UserDefinedType ast1))) (Select UserDefinedType ast2)
+    , StripLocation (Select TypeKind ast1) (Select TypeKind ast2)
     ) =>
     Type ast1 ->
     Type ast2

--- a/src/Elara/AST/Generic/Pattern.hs
+++ b/src/Elara/AST/Generic/Pattern.hs
@@ -3,13 +3,14 @@
 module Elara.AST.Generic.Pattern where
 
 import Elara.AST.Generic
+import Elara.AST.Select
 
 pattern FunctionCall' :: ASTLocate ast1 (Expr' ast1) ~ Expr' ast2 => Expr ast2 -> Expr ast2 -> Expr ast1
 pattern FunctionCall' a b <- Expr (FunctionCall a b, _)
 
 functionCall ::
     forall a {a1} {a2} {ast1 :: a1} {ast2 :: a2}.
-    (ASTLocate ast1 (Expr' ast1) ~ Expr' ast2, Select "ExprType" ast1 ~ Maybe a) =>
+    (ASTLocate ast1 (Expr' ast1) ~ Expr' ast2, Select (ASTType ForExpr) ast1 ~ Maybe a) =>
     Expr ast2 ->
     Expr ast2 ->
     Expr ast1
@@ -18,16 +19,16 @@ functionCall a b = Expr (FunctionCall a b, Nothing)
 var ::
     forall {a1} {a2} {ast1 :: a1} {ast2 :: a2} {a3}.
     ( ASTLocate ast1 (Expr' ast1) ~ Expr' ast2
-    , Select "ExprType" ast1 ~ Maybe a3
+    , Select (ASTType ForExpr) ast1 ~ Maybe a3
     ) =>
-    ASTLocate ast2 (Select "VarRef" ast2) ->
+    ASTLocate ast2 (Select ASTVarRef ast2) ->
     Expr ast1
 var a = Expr (Var a, Nothing)
 
 int ::
     forall {a1} {a2} {ast1 :: a1} {ast2 :: a2} {a3}.
     ( CleanupLocated (ASTLocate' ast1 (Expr' ast1)) ~ Expr' ast2
-    , Select "ExprType" ast1 ~ Maybe a3
+    , Select (ASTType ForExpr) ast1 ~ Maybe a3
     ) =>
     Integer ->
     Expr ast1

--- a/src/Elara/AST/Generic/Types.hs
+++ b/src/Elara/AST/Generic/Types.hs
@@ -312,7 +312,11 @@ class RUnlocate ast where
         a
     rUnlocate = view (rUnlocated @_ @ast @a)
 
-    rUnlocated :: forall a. CleanupLocated (Located a) ~ Located a => Getter (ASTLocate ast a) a
+    rUnlocated ::
+        forall a.
+        CleanupLocated (Located a)
+            ~ Located a =>
+        Getter (ASTLocate ast a) a
 
     fmapUnlocated ::
         forall a b.

--- a/src/Elara/AST/Introspection.hs
+++ b/src/Elara/AST/Introspection.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE TypeAbstractions #-}
+
+-- | Defines useful classes and functions for introspecting ASTs
+module Elara.AST.Introspection where
+
+import Elara.AST.Generic.Types
+import Elara.AST.Renamed ()
+import Elara.AST.Select
+
+-- | Value-level proof that an AST's annotations can be coerced to a specific type over all selectors
+class IntrospectableAnnotations ast where
+    -- | Get all annotations for a given selector in the AST
+    getAnnotations :: forall sel. Select (Annotations sel) ast -> [Annotation ast]
+
+instance IntrospectableAnnotations Renamed where
+    getAnnotations a = a

--- a/src/Elara/AST/Kinded.hs
+++ b/src/Elara/AST/Kinded.hs
@@ -8,7 +8,7 @@ module Elara.AST.Kinded where
 import Elara.AST.Generic
 import Elara.AST.Name (Qualified)
 import Elara.AST.Region (Located (..))
-import Elara.AST.Select (LocatedAST (Kinded, MidKinded, Shunted))
+import Elara.AST.Select (ASTSelector (..), LocatedAST (Kinded, MidKinded, Shunted))
 import Elara.Data.Kind (ElaraKind)
 import Elara.Data.Unique (UniqueId)
 
@@ -25,15 +25,15 @@ type instance Select x 'Kinded = ReplaceKinded x (Select x 'MidKinded)
 type instance Select x 'MidKinded = ReplaceMidKinded x (Select x 'Shunted)
 
 type family ReplaceKinded x r where
-    ReplaceKinded "KindAnnotation" r = ElaraKind
-    ReplaceKinded "TypeKind" r = ElaraKind
-    ReplaceKinded "ADTParam" r = KindedType
-    ReplaceKinded "Alias" r = KindedType
+    ReplaceKinded KindAnnotation r = ElaraKind
+    ReplaceKinded TypeKind r = ElaraKind
+    ReplaceKinded ADTParam r = KindedType
+    ReplaceKinded Alias r = KindedType
     ReplaceKinded x r = r
 
 type family ReplaceMidKinded x r where
-    ReplaceMidKinded "TypeKind" r = UniqueId
-    ReplaceMidKinded "ADTParam" r = MidKindedType
+    ReplaceMidKinded TypeKind r = UniqueId
+    ReplaceMidKinded ADTParam r = MidKindedType
     ReplaceMidKinded x r = r
 
 type KindedTypeDeclaration = TypeDeclaration 'Kinded

--- a/src/Elara/AST/Pretty.hs
+++ b/src/Elara/AST/Pretty.hs
@@ -7,6 +7,7 @@ module Elara.AST.Pretty where
 
 import Data.Generics.Wrapped
 import Elara.AST.Generic.Types
+import Elara.AST.Select (ASTSelector (..), ForSelector (ForValueDecl))
 import Elara.Data.Pretty
 import Elara.Data.Pretty.Styles
 import Prelude hiding (group)
@@ -146,7 +147,10 @@ prettyList l =
 prettyConsPattern :: (Pretty a1, Pretty a2) => a1 -> a2 -> Doc AnsiStyle
 prettyConsPattern e1 e2 = parens (pretty e1 <+> "::" <+> pretty e2)
 
-prettyValueDeclaration :: forall ast a1 a2 a3. (Pretty a1, Pretty a2, Pretty a3, Pretty (InfixDeclaration ast)) => a1 -> a2 -> Maybe a3 -> ValueDeclAnnotations ast -> Doc AnsiStyle
+prettyValueDeclaration ::
+    forall ast a1 a2 a3.
+    (Pretty a1, Pretty a2, Pretty a3, Pretty (Select (Annotations ForValueDecl) ast)) =>
+    a1 -> a2 -> Maybe a3 -> ValueDeclAnnotations ast -> Doc AnsiStyle
 prettyValueDeclaration name e expectedType anns =
     let defLine = prettyValueTypeDef name <$> expectedType
         annLine = prettyValueDeclAnnotations anns
@@ -157,9 +161,8 @@ prettyValueDeclaration name e expectedType anns =
             ]
      in vsep (maybeToList defLine <> [annLine] <> rest)
 
-prettyValueDeclAnnotations :: Pretty (InfixDeclaration ast) => ValueDeclAnnotations ast -> Doc AnsiStyle
-prettyValueDeclAnnotations (ValueDeclAnnotations Nothing _) = ""
-prettyValueDeclAnnotations (ValueDeclAnnotations (Just x) _) = pretty x
+prettyValueDeclAnnotations :: Pretty (Select (Annotations ForValueDecl) ast) => ValueDeclAnnotations ast -> Doc AnsiStyle
+prettyValueDeclAnnotations (ValueDeclAnnotations x) = pretty x
 
 prettyValueTypeDef :: (Pretty a1, Pretty a2) => a1 -> a2 -> Doc AnsiStyle
 prettyValueTypeDef name t = keyword "def" <+> pretty name <+> punctuation ":" <+> pretty t

--- a/src/Elara/AST/Pretty.hs
+++ b/src/Elara/AST/Pretty.hs
@@ -158,8 +158,8 @@ prettyValueDeclaration name e expectedType anns =
      in vsep (maybeToList defLine <> [annLine] <> rest)
 
 prettyValueDeclAnnotations :: Pretty (InfixDeclaration ast) => ValueDeclAnnotations ast -> Doc AnsiStyle
-prettyValueDeclAnnotations (ValueDeclAnnotations Nothing) = ""
-prettyValueDeclAnnotations (ValueDeclAnnotations (Just x)) = pretty x
+prettyValueDeclAnnotations (ValueDeclAnnotations Nothing _) = ""
+prettyValueDeclAnnotations (ValueDeclAnnotations (Just x) _) = pretty x
 
 prettyValueTypeDef :: (Pretty a1, Pretty a2) => a1 -> a2 -> Doc AnsiStyle
 prettyValueTypeDef name t = keyword "def" <+> pretty name <+> punctuation ":" <+> pretty t

--- a/src/Elara/AST/Renamed.hs
+++ b/src/Elara/AST/Renamed.hs
@@ -76,9 +76,6 @@ type instance Select (Annotations ForTypeDecl) Renamed = NoFieldValue
 type instance Select KindAnnotation Renamed = NoFieldValue
 
 -- Selections for 'Declaration'
--- type instance Select DeclarationName Renamed = Qualified Name
-
-type instance Select AnyName Renamed = Name
 
 type instance Select (ASTName ForTypeDecl) Renamed = Qualified TypeName
 type instance Select (ASTName ForType) Renamed = Qualified TypeName

--- a/src/Elara/AST/Renamed.hs
+++ b/src/Elara/AST/Renamed.hs
@@ -69,9 +69,8 @@ type instance Select Alias Renamed = RenamedType
 
 type instance Select ADTParam Renamed = RenamedType
 
-type instance Select (Annotations ForValueDecl) Renamed = NoFieldValue
-
-type instance Select (Annotations ForTypeDecl) Renamed = NoFieldValue
+type instance Select AnnotationName Renamed = Qualified TypeName
+type instance Select (Annotations x) Renamed = [Annotation Renamed]
 
 type instance Select KindAnnotation Renamed = NoFieldValue
 

--- a/src/Elara/AST/Renamed.hs
+++ b/src/Elara/AST/Renamed.hs
@@ -73,8 +73,6 @@ type instance Select (Annotations ForValueDecl) Renamed = NoFieldValue
 
 type instance Select (Annotations ForTypeDecl) Renamed = NoFieldValue
 
-type instance Select InfixDecl Renamed = DataConCantHappen
-
 type instance Select KindAnnotation Renamed = NoFieldValue
 
 -- Selections for 'Declaration'

--- a/src/Elara/AST/Renamed.hs
+++ b/src/Elara/AST/Renamed.hs
@@ -10,7 +10,7 @@ import Elara.AST.Generic
 import Elara.AST.Generic.Common
 import Elara.AST.Name (LowerAlphaName, Name, OpName, Qualified, TypeName, VarName, VarOrConName)
 import Elara.AST.Region (Located (..))
-import Elara.AST.Select (LocatedAST (Renamed))
+import Elara.AST.Select (ASTSelector (..), ForSelector (..), LocatedAST (Renamed))
 import Elara.AST.VarRef (VarRef)
 import Elara.Data.Unique (Unique)
 
@@ -19,88 +19,81 @@ type instance ASTLocate' Renamed = Located
 type instance ASTQual Renamed = Qualified
 
 -- Selections for 'Expr'
-type instance Select "ExprType" Renamed = Maybe RenamedType
+type instance Select (ASTType ForExpr) Renamed = Maybe RenamedType
 
-type instance Select "LambdaPattern" Renamed = TypedLambdaParam (Unique VarName) Renamed
+type instance Select LambdaPattern Renamed = TypedLambdaParam (Unique VarName) Renamed
 
-type instance Select "LetPattern" Renamed = NoFieldValue
+type instance Select LetPattern Renamed = NoFieldValue
 
-type instance Select "VarRef" Renamed = VarRef VarName
+type instance Select ASTVarRef Renamed = VarRef VarName
 
-type instance Select "ConRef" Renamed = Qualified TypeName
+type instance Select ConRef Renamed = Qualified TypeName
 
-type instance Select "SymOp" Renamed = VarRef OpName
+type instance Select SymOp Renamed = VarRef OpName
 
-type instance Select "Infixed" Renamed = VarRef VarOrConName
+type instance Select Infixed Renamed = VarRef VarOrConName
 
-type instance Select "LetParamName" Renamed = Unique VarName
+type instance Select LetParamName Renamed = Unique VarName
 
-type instance Select "InParens" Renamed = RenamedExpr
+type instance Select InParens Renamed = RenamedExpr
 
-type instance Select "Tuple" Renamed = DataConCantHappen
+type instance Select Tuple Renamed = DataConCantHappen
 
-type instance Select "List" Renamed = DataConCantHappen
+type instance Select List Renamed = DataConCantHappen
 
-type instance Select "BinaryOperator" Renamed = (RenamedBinaryOperator, RenamedExpr, RenamedExpr)
+type instance Select ASTBinaryOperator Renamed = (RenamedBinaryOperator, RenamedExpr, RenamedExpr)
 
-type instance Select "PatternType" Renamed = Maybe RenamedType
+type instance Select PatternType Renamed = Maybe RenamedType
 
-type instance Select "VarPat" Renamed = Unique LowerAlphaName
+type instance Select VarPat Renamed = Unique LowerAlphaName
 
-type instance Select "ConPat" Renamed = Qualified TypeName
+type instance Select ConPat Renamed = Qualified TypeName
 
-type instance Select "ConsPattern" Renamed = DataConCantHappen
+type instance Select ConsPattern Renamed = DataConCantHappen
 
-type instance Select "ListPattern" Renamed = DataConCantHappen
-type instance Select "TuplePattern" Renamed = DataConCantHappen
+type instance Select ListPattern Renamed = DataConCantHappen
+type instance Select TuplePattern Renamed = DataConCantHappen
 
-type instance Select "TypeApplication" Renamed = RenamedType
+type instance Select TypeApplication Renamed = RenamedType
 
 -- Selections for 'DeclarationBody'
-type instance Select "ValuePatterns" Renamed = NoFieldValue
+type instance Select (Patterns ForValueDecl) Renamed = NoFieldValue
 
-type instance Select "TypeKind" Renamed = NoFieldValue
+type instance Select TypeKind Renamed = NoFieldValue
 
-type instance Select "ValueType" Renamed = Maybe RenamedType
+type instance Select (ASTType ForValueDecl) Renamed = Maybe RenamedType
 
-type instance Select "ValueTypeDef" Renamed = DataConCantHappen
+type instance Select ValueTypeDef Renamed = DataConCantHappen
 
-type instance Select "Alias" Renamed = RenamedType
+type instance Select Alias Renamed = RenamedType
 
-type instance Select "ADTParam" Renamed = RenamedType
+type instance Select ADTParam Renamed = RenamedType
 
-type instance Select "ValueDeclAnnotations" Renamed = RenamedValueDeclAnnotations
+type instance Select (Annotations ForValueDecl) Renamed = NoFieldValue
 
-type instance Select "TypeDeclAnnotations" Renamed = RenamedTypeDeclAnnotations
+type instance Select (Annotations ForTypeDecl) Renamed = NoFieldValue
 
-type instance Select "InfixDecl" Renamed = DataConCantHappen
+type instance Select InfixDecl Renamed = DataConCantHappen
 
-type instance Select "KindAnnotation" Renamed = NoFieldValue
-
-newtype RenamedValueDeclAnnotations = RenamedValueDeclAnnotations
-    { infixValueDecl :: Maybe (InfixDeclaration Renamed)
-    }
-
-newtype RenamedTypeDeclAnnotations = RenamedTypeDeclAnnotations
-    { infixTypeDecl :: Maybe (InfixDeclaration Renamed)
-    }
-    deriving (Show)
+type instance Select KindAnnotation Renamed = NoFieldValue
 
 -- Selections for 'Declaration'
-type instance Select "DeclarationName" Renamed = Qualified Name
+-- type instance Select DeclarationName Renamed = Qualified Name
 
-type instance Select "AnyName" Renamed = Name
+type instance Select AnyName Renamed = Name
 
-type instance Select "TypeName" Renamed = Qualified TypeName
+type instance Select (ASTName ForTypeDecl) Renamed = Qualified TypeName
+type instance Select (ASTName ForType) Renamed = Qualified TypeName
 
-type instance Select "ValueName" Renamed = Qualified VarName
+type instance Select (ASTName ForValueDecl) Renamed = Qualified VarName
+type instance Select (ASTName ForExpr) Renamed = Qualified VarName
 
 -- Selections for 'Type'
-type instance Select "TypeVar" Renamed = Unique LowerAlphaName
+type instance Select ASTTypeVar Renamed = Unique LowerAlphaName
 
-type instance Select "UserDefinedType" Renamed = Qualified TypeName
+type instance Select UserDefinedType Renamed = Qualified TypeName
 
-type instance Select "ConstructorName" Renamed = Qualified TypeName
+type instance Select ConstructorName Renamed = Qualified TypeName
 
 type RenamedExpr = Expr Renamed
 

--- a/src/Elara/AST/Select.hs
+++ b/src/Elara/AST/Select.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE TypeData #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Elara.AST.Select where
@@ -8,3 +9,44 @@ data LocatedAST = Frontend | Desugared | Renamed | Shunted | MidKinded | Kinded 
 
 -- type UnlocatedAST :: AST
 data UnlocatedAST = UnlocatedFrontend | UnlocatedDesugared | UnlocatedRenamed | UnlocatedShunted | UnlocatedTyped
+
+type data ASTSelector
+    = ASTVarRef
+    | ConRef
+    | LambdaPattern
+    | TypeApplication
+    | PatternType
+    | ASTBinaryOperator
+    | List
+    | LetParamName
+    | LetPattern
+    | ConstructorName
+    | ADTParam
+    | Alias
+    | Annotations ForSelector
+    | KindAnnotation
+    | ASTTypeVar
+    | TypeKind
+    | UserDefinedType
+    | InfixDecl
+    | ASTName ForSelector
+    | Patterns ForSelector
+    | ASTType ForSelector
+    | AnyName
+    | VarPat
+    | ConPat
+    | AnnotationName
+    | ValueTypeDef
+    | Tuple
+    | InParens
+    | ListPattern
+    | TuplePattern
+    | ConsPattern
+    | SymOp
+    | Infixed
+
+type data ForSelector
+    = ForType
+    | ForTypeDecl
+    | ForValueDecl
+    | ForExpr

--- a/src/Elara/AST/Select.hs
+++ b/src/Elara/AST/Select.hs
@@ -4,11 +4,23 @@
 
 module Elara.AST.Select where
 
--- type LocatedAST :: AST
 data LocatedAST = Frontend | Desugared | Renamed | Shunted | MidKinded | Kinded | Typed | Core
 
--- type UnlocatedAST :: AST
 data UnlocatedAST = UnlocatedFrontend | UnlocatedDesugared | UnlocatedRenamed | UnlocatedShunted | UnlocatedTyped
+
+type family LocatedToUnlocated (ast :: LocatedAST) :: UnlocatedAST where
+    LocatedToUnlocated 'Frontend = 'UnlocatedFrontend
+    LocatedToUnlocated 'Desugared = 'UnlocatedDesugared
+    LocatedToUnlocated 'Renamed = 'UnlocatedRenamed
+    LocatedToUnlocated 'Shunted = 'UnlocatedShunted
+    LocatedToUnlocated 'Typed = 'UnlocatedTyped
+
+type family UnlocatedToLocated (ast :: UnlocatedAST) :: LocatedAST where
+    UnlocatedToLocated 'UnlocatedFrontend = 'Frontend
+    UnlocatedToLocated 'UnlocatedDesugared = 'Desugared
+    UnlocatedToLocated 'UnlocatedRenamed = 'Renamed
+    UnlocatedToLocated 'UnlocatedShunted = 'Shunted
+    UnlocatedToLocated 'UnlocatedTyped = 'Typed
 
 {- | Elements of the AST that are parametric by their AST stage
 This type acts as a selector for the 'Select' type family for these elements

--- a/src/Elara/AST/Select.hs
+++ b/src/Elara/AST/Select.hs
@@ -54,18 +54,28 @@ type data ASTSelector
       Patterns ForSelector
     | -- | Type of types of specific elements
       ASTType ForSelector
-    | AnyName
-    | VarPat
-    | ConPat
-    | AnnotationName
-    | ValueTypeDef
-    | Tuple
-    | InParens
-    | ListPattern
-    | TuplePattern
-    | ConsPattern
-    | SymOp
-    | Infixed
+    | -- | Type used for the value of variable patterns, i.e. a variable name
+      VarPat
+    | -- | Type used for the value of constructor patterns, i.e. a constructor name
+      ConPat
+    | -- | Type used for the name of an annotation
+      AnnotationName
+    | -- | Type used for the <type> part in a @def <name> : <type>@ statement
+      ValueTypeDef
+    | -- | Type of a tuple expression
+      Tuple
+    | -- | Type of an expression wrapped in parenthesis
+      InParens
+    | -- | A list literal pattern
+      ListPattern
+    | -- | A tuple literal pattern
+      TuplePattern
+    | -- | A cons literal pattern
+      ConsPattern
+    | -- | An operator's name that is symbolic, i.e. made of symbols
+      SymOp
+    | -- | The name of the "operator" in an infix (e.g. @a `f` b@) expression
+      Infixed
 
 type data ForSelector
     = ForType

--- a/src/Elara/AST/Select.hs
+++ b/src/Elara/AST/Select.hs
@@ -10,28 +10,50 @@ data LocatedAST = Frontend | Desugared | Renamed | Shunted | MidKinded | Kinded 
 -- type UnlocatedAST :: AST
 data UnlocatedAST = UnlocatedFrontend | UnlocatedDesugared | UnlocatedRenamed | UnlocatedShunted | UnlocatedTyped
 
+{- | Elements of the AST that are parametric by their AST stage
+This type acts as a selector for the 'Select' type family for these elements
+-}
 type data ASTSelector
-    = ASTVarRef
-    | ConRef
-    | LambdaPattern
-    | TypeApplication
-    | PatternType
-    | ASTBinaryOperator
-    | List
-    | LetParamName
-    | LetPattern
-    | ConstructorName
-    | ADTParam
-    | Alias
-    | Annotations ForSelector
-    | KindAnnotation
-    | ASTTypeVar
-    | TypeKind
-    | UserDefinedType
-    | InfixDecl
-    | ASTName ForSelector
-    | Patterns ForSelector
-    | ASTType ForSelector
+    = -- | The type used for references to variables
+      ASTVarRef
+    | -- | References to type / data constructors
+      ConRef
+    | -- | Patterns that can be bound in a lambda expression (eg @\[a] (b, c) -> ...@)
+      LambdaPattern
+    | -- | The value stored in type application nodes (usually a 'Type')
+      TypeApplication
+    | -- | The type used to represent an explicit type declaration for patterns, e.g. @[Int]@ in @f ([y] :: [Int])@
+      PatternType
+    | -- | Value of binary operator nodes. Replaced with 'NoFieldValue' after shunting
+      ASTBinaryOperator
+    | -- | Value of list expressions
+      List
+    | -- | Type used for the name of a value bound by a @let@ expression
+      LetParamName
+    | -- | Patterns that can be bound in a @let@ expression
+      LetPattern
+    | -- | Type used for the name of a constructor within its declaration only. Often differs to 'ConRef' in what types of qualification it allows
+      ConstructorName
+    | -- | Type of parameters for a data constructor in its declaration, e.g.the second @a@ in @type Box a = Box a@
+      ADTParam
+    | -- | Type used for the RHS of a type alias declaration
+      Alias
+    | -- | Type of annotations for a selected AST node type
+      Annotations ForSelector
+    | -- | Type for Kind annotations upon a type declaration only
+      KindAnnotation
+    | -- | Type of type variables used in any way
+      ASTTypeVar
+    | -- | Type for the actual kind of a type stored within the 'Type', i.e. at use sites. Will probably be merged with 'KindAnnotation' as they aren't clearly distinguishable
+      TypeKind
+    | -- | Type for a reference to a user defined type, i.e. a named type that is not a primitive. Usually similar/identical to 'ConRef'
+      UserDefinedType
+    | -- | Type of a name of a specific element
+      ASTName ForSelector
+    | -- | Type of pattern(s) that can be bound by a specific element
+      Patterns ForSelector
+    | -- | Type of types of specific elements
+      ASTType ForSelector
     | AnyName
     | VarPat
     | ConPat

--- a/src/Elara/AST/Shunted.hs
+++ b/src/Elara/AST/Shunted.hs
@@ -75,9 +75,6 @@ type instance Select Alias 'Shunted = ShuntedType
 type instance Select ADTParam 'Shunted = ShuntedType
 
 -- Selections for 'Declaration'
--- type instance Select DeclarationName 'Shunted = Qualified Name
-
-type instance Select AnyName Shunted = Name
 
 type instance Select (ASTName ForType) Shunted = Qualified TypeName
 

--- a/src/Elara/AST/Shunted.hs
+++ b/src/Elara/AST/Shunted.hs
@@ -12,7 +12,7 @@ module Elara.AST.Shunted where
 
 import Elara.AST.Generic
 import Elara.AST.Generic.Common
-import Elara.AST.Name (LowerAlphaName, Name (..), OpName, Qualified (..), TypeName, VarName)
+import Elara.AST.Name (LowerAlphaName, OpName, Qualified (..), TypeName, VarName)
 import Elara.AST.Region (Located (..))
 import Elara.AST.Select (ASTSelector (..), ForSelector (..), LocatedAST (Shunted))
 import Elara.AST.VarRef (VarRef)
@@ -90,7 +90,8 @@ type instance Select UserDefinedType 'Shunted = Qualified TypeName
 
 type instance Select ConstructorName 'Shunted = Qualified TypeName
 
-type instance Select (Annotations a) 'Shunted = NoFieldValue
+type instance Select AnnotationName 'Shunted = Qualified TypeName
+type instance Select (Annotations a) 'Shunted = [Annotation Shunted]
 
 type ShuntedExpr = Expr 'Shunted
 

--- a/src/Elara/AST/Shunted.hs
+++ b/src/Elara/AST/Shunted.hs
@@ -14,7 +14,7 @@ import Elara.AST.Generic
 import Elara.AST.Generic.Common
 import Elara.AST.Name (LowerAlphaName, Name (..), OpName, Qualified (..), TypeName, VarName)
 import Elara.AST.Region (Located (..))
-import Elara.AST.Select (LocatedAST (Shunted))
+import Elara.AST.Select (ASTSelector (..), ForSelector (..), LocatedAST (Shunted))
 import Elara.AST.VarRef (VarRef)
 import Elara.Data.Unique (Unique)
 
@@ -23,76 +23,79 @@ type instance ASTLocate' 'Shunted = Located
 type instance ASTQual 'Shunted = Qualified
 
 -- Selections for 'Expr'
-type instance Select "ExprType" 'Shunted = Maybe ShuntedType
+type instance Select (ASTType ForExpr) 'Shunted = Maybe ShuntedType
 
-type instance Select "LambdaPattern" 'Shunted = TypedLambdaParam (Unique VarName) 'Shunted
+type instance Select LambdaPattern 'Shunted = TypedLambdaParam (Unique VarName) 'Shunted
 
-type instance Select "LetPattern" 'Shunted = NoFieldValue
+type instance Select LetPattern 'Shunted = NoFieldValue
 
-type instance Select "VarRef" 'Shunted = VarRef VarName
+type instance Select ASTVarRef 'Shunted = VarRef VarName
 
-type instance Select "ConRef" 'Shunted = Qualified TypeName
+type instance Select ConRef 'Shunted = Qualified TypeName
 
-type instance Select "SymOp" 'Shunted = VarRef OpName
+type instance Select SymOp 'Shunted = VarRef OpName
 
-type instance Select "Infixed" 'Shunted = VarRef VarName
+type instance Select Infixed 'Shunted = VarRef VarName
 
-type instance Select "LetParamName" 'Shunted = Unique VarName
+type instance Select LetParamName 'Shunted = Unique VarName
 
-type instance Select "InParens" 'Shunted = DataConCantHappen
+type instance Select InParens 'Shunted = DataConCantHappen
 
-type instance Select "List" 'Shunted = DataConCantHappen
+type instance Select List 'Shunted = DataConCantHappen
 
-type instance Select "Tuple" 'Shunted = DataConCantHappen
+type instance Select Tuple 'Shunted = DataConCantHappen
 
-type instance Select "BinaryOperator" 'Shunted = DataConCantHappen
+type instance Select ASTBinaryOperator 'Shunted = DataConCantHappen
 
-type instance Select "PatternType" 'Shunted = Maybe ShuntedType
+type instance Select PatternType 'Shunted = Maybe ShuntedType
 
-type instance Select "VarPat" 'Shunted = Unique LowerAlphaName
+type instance Select VarPat 'Shunted = Unique LowerAlphaName
 
-type instance Select "ConPat" 'Shunted = Qualified TypeName
+type instance Select ConPat 'Shunted = Qualified TypeName
 
-type instance Select "ConsPattern" 'Shunted = DataConCantHappen
+type instance Select ConsPattern 'Shunted = DataConCantHappen
 
-type instance Select "ListPattern" 'Shunted = DataConCantHappen
+type instance Select ListPattern 'Shunted = DataConCantHappen
 
-type instance Select "TuplePattern" 'Shunted = DataConCantHappen
+type instance Select TuplePattern 'Shunted = DataConCantHappen
 
-type instance Select "TypeApplication" 'Shunted = ShuntedType
+type instance Select TypeApplication 'Shunted = ShuntedType
 
 -- Selections for 'DeclarationBody'
-type instance Select "ValuePatterns" 'Shunted = NoFieldValue
+type instance Select (Patterns ForValueDecl) 'Shunted = NoFieldValue
 
-type instance Select "ValueType" 'Shunted = Maybe ShuntedType
+type instance Select (ASTType ForValueDecl) 'Shunted = Maybe ShuntedType
 
-type instance Select "ValueTypeDef" 'Shunted = DataConCantHappen
+type instance Select ValueTypeDef 'Shunted = DataConCantHappen
 
-type instance Select "InfixDecl" 'Shunted = DataConCantHappen
+type instance Select InfixDecl 'Shunted = DataConCantHappen
 
-type instance Select "KindAnnotation" 'Shunted = NoFieldValue
+type instance Select KindAnnotation 'Shunted = NoFieldValue
 
-type instance Select "Alias" 'Shunted = ShuntedType
+type instance Select Alias 'Shunted = ShuntedType
 
-type instance Select "ADTParam" 'Shunted = ShuntedType
+type instance Select ADTParam 'Shunted = ShuntedType
 
 -- Selections for 'Declaration'
-type instance Select "DeclarationName" 'Shunted = Qualified Name
+-- type instance Select DeclarationName 'Shunted = Qualified Name
 
-type instance Select "AnyName" Shunted = Name
+type instance Select AnyName Shunted = Name
 
-type instance Select "TypeName" Shunted = Qualified TypeName
+type instance Select (ASTName ForType) Shunted = Qualified TypeName
 
-type instance Select "ValueName" Shunted = Qualified VarName
+type instance Select (ASTName ForExpr) Shunted = Qualified VarName
+type instance Select (ASTName ForValueDecl) Shunted = Qualified VarName
 
 -- Selections for 'Type'
-type instance Select "TypeKind" 'Shunted = NoFieldValue
+type instance Select TypeKind 'Shunted = NoFieldValue
 
-type instance Select "TypeVar" 'Shunted = Unique LowerAlphaName
+type instance Select ASTTypeVar 'Shunted = Unique LowerAlphaName
 
-type instance Select "UserDefinedType" 'Shunted = Qualified TypeName
+type instance Select UserDefinedType 'Shunted = Qualified TypeName
 
-type instance Select "ConstructorName" 'Shunted = Qualified TypeName
+type instance Select ConstructorName 'Shunted = Qualified TypeName
+
+type instance Select (Annotations a) 'Shunted = NoFieldValue
 
 type ShuntedExpr = Expr 'Shunted
 

--- a/src/Elara/AST/Shunted.hs
+++ b/src/Elara/AST/Shunted.hs
@@ -12,11 +12,14 @@ module Elara.AST.Shunted where
 
 import Elara.AST.Generic
 import Elara.AST.Generic.Common
+import Elara.AST.Introspection
 import Elara.AST.Name (LowerAlphaName, OpName, Qualified (..), TypeName, VarName)
 import Elara.AST.Region (Located (..))
 import Elara.AST.Select (ASTSelector (..), ForSelector (..), LocatedAST (Shunted))
 import Elara.AST.VarRef (VarRef)
 import Elara.Data.Unique (Unique)
+import Elara.Query
+import Elara.Query.Errors
 
 type instance ASTLocate' 'Shunted = Located
 

--- a/src/Elara/AST/Shunted.hs
+++ b/src/Elara/AST/Shunted.hs
@@ -68,8 +68,6 @@ type instance Select (ASTType ForValueDecl) 'Shunted = Maybe ShuntedType
 
 type instance Select ValueTypeDef 'Shunted = DataConCantHappen
 
-type instance Select InfixDecl 'Shunted = DataConCantHappen
-
 type instance Select KindAnnotation 'Shunted = NoFieldValue
 
 type instance Select Alias 'Shunted = ShuntedType

--- a/src/Elara/AST/Typed.hs
+++ b/src/Elara/AST/Typed.hs
@@ -15,7 +15,7 @@ import Elara.AST.Generic qualified as Generic
 import Elara.AST.Generic.Common
 import Elara.AST.Name (Name (..), OpName, Qualified (..), TypeName (..), VarName)
 import Elara.AST.Region (Located (..), SourceRegion, unlocated)
-import Elara.AST.Select (LocatedAST (Typed))
+import Elara.AST.Select (ASTSelector (..), ForSelector (..), LocatedAST (Typed))
 import Elara.AST.VarRef (VarRef, VarRef' (Global))
 import Elara.Data.Kind (ElaraKind)
 import Elara.Data.TopologicalGraph
@@ -29,76 +29,78 @@ type instance ASTLocate' 'Typed = Located
 type instance ASTQual 'Typed = Qualified
 
 -- Selections for 'Expr'
-type instance Select "ExprType" 'Typed = Monotype SourceRegion
+type instance Select (ASTType ForExpr) 'Typed = Monotype SourceRegion
 
-type instance Select "LambdaPattern" 'Typed = TypedLambdaParam (Unique VarName) 'Typed
+type instance Select LambdaPattern 'Typed = TypedLambdaParam (Unique VarName) 'Typed
 
-type instance Select "LetPattern" 'Typed = NoFieldValue
+type instance Select LetPattern 'Typed = NoFieldValue
 
 -- VarRefs may have polytypes
-type instance Select "VarRef" 'Typed = (VarRef VarName, Type SourceRegion)
+type instance Select ASTVarRef 'Typed = (VarRef VarName, Type SourceRegion)
 
-type instance Select "ConRef" 'Typed = Qualified TypeName
+type instance Select ConRef 'Typed = Qualified TypeName
 
-type instance Select "SymOp" 'Typed = VarRef OpName
+type instance Select SymOp 'Typed = VarRef OpName
 
-type instance Select "Infixed" 'Typed = VarRef VarName
+type instance Select Infixed 'Typed = VarRef VarName
 
-type instance Select "LetParamName" 'Typed = Unique VarName
+type instance Select LetParamName 'Typed = Unique VarName
 
-type instance Select "InParens" 'Typed = DataConCantHappen
+type instance Select InParens 'Typed = DataConCantHappen
 
-type instance Select "List" 'Typed = DataConCantHappen
+type instance Select List 'Typed = DataConCantHappen
 
-type instance Select "Tuple" 'Typed = DataConCantHappen
+type instance Select Tuple 'Typed = DataConCantHappen
 
-type instance Select "BinaryOperator" 'Typed = DataConCantHappen
+type instance Select ASTBinaryOperator 'Typed = DataConCantHappen
 
-type instance Select "PatternType" 'Typed = Monotype SourceRegion
+type instance Select PatternType 'Typed = Monotype SourceRegion
 
-type instance Select "VarPat" 'Typed = Unique VarName
+type instance Select VarPat 'Typed = Unique VarName
 
-type instance Select "ConPat" 'Typed = Qualified TypeName
+type instance Select ConPat 'Typed = Qualified TypeName
 
-type instance Select "ListPattern" 'Typed = DataConCantHappen
+type instance Select ListPattern 'Typed = DataConCantHappen
 
-type instance Select "ConsPattern" 'Typed = DataConCantHappen
-type instance Select "TuplePattern" 'Typed = DataConCantHappen
+type instance Select ConsPattern 'Typed = DataConCantHappen
+type instance Select TuplePattern 'Typed = DataConCantHappen
 
-type instance Select "TypeApplication" Typed = Monotype SourceRegion
+type instance Select TypeApplication 'Typed = Monotype SourceRegion
 
 -- Selections for 'DeclarationBody'
-type instance Select "ValuePatterns" 'Typed = NoFieldValue
+type instance Select (Patterns ForValueDecl) 'Typed = NoFieldValue
 
-type instance Select "ValueType" 'Typed = Type SourceRegion
+type instance Select (ASTType ForValueDecl) 'Typed = Type SourceRegion
 
-type instance Select "ValueTypeDef" 'Typed = DataConCantHappen
+type instance Select ValueTypeDef 'Typed = DataConCantHappen
 
-type instance Select "InfixDecl" 'Typed = DataConCantHappen
+type instance Select InfixDecl 'Typed = DataConCantHappen
 
-type instance Select "Alias" 'Typed = (Type SourceRegion, ElaraKind)
+type instance Select Alias 'Typed = (Type SourceRegion, ElaraKind)
 
-type instance Select "ADTParam" 'Typed = (Monotype SourceRegion, ElaraKind)
+type instance Select ADTParam 'Typed = (Monotype SourceRegion, ElaraKind)
 
 -- Selections for 'Declaration'
-type instance Select "DeclarationName" 'Typed = Qualified Name
+-- type instance Select DeclarationName 'Typed = Qualified Name
 
-type instance Select "AnyName" Typed = Name
+type instance Select AnyName Typed = Name
 
-type instance Select "TypeName" Typed = Qualified TypeName
+type instance Select (ASTName ForType) Typed = Qualified TypeName
 
-type instance Select "ValueName" Typed = Qualified VarName
+type instance Select (ASTName ForValueDecl) Typed = Qualified VarName
 
 -- Selections for 'Type'
-type instance Select "TypeVar" 'Typed = UniqueTyVar
+type instance Select ASTTypeVar 'Typed = UniqueTyVar
 
-type instance Select "TypeKind" 'Typed = ElaraKind
+type instance Select TypeKind 'Typed = ElaraKind
 
-type instance Select "KindAnnotation" 'Typed = ElaraKind
+type instance Select KindAnnotation 'Typed = ElaraKind
 
-type instance Select "UserDefinedType" 'Typed = Qualified TypeName
+type instance Select UserDefinedType 'Typed = Qualified TypeName
 
-type instance Select "ConstructorName" 'Typed = Qualified TypeName
+type instance Select ConstructorName 'Typed = Qualified TypeName
+
+type instance Select (Annotations a) 'Typed = NoFieldValue
 
 type TypedExpr = Generic.Expr 'Typed
 

--- a/src/Elara/AST/Typed.hs
+++ b/src/Elara/AST/Typed.hs
@@ -79,9 +79,6 @@ type instance Select Alias 'Typed = (Type SourceRegion, ElaraKind)
 type instance Select ADTParam 'Typed = (Monotype SourceRegion, ElaraKind)
 
 -- Selections for 'Declaration'
--- type instance Select DeclarationName 'Typed = Qualified Name
-
-type instance Select AnyName Typed = Name
 
 type instance Select (ASTName ForType) Typed = Qualified TypeName
 

--- a/src/Elara/AST/Typed.hs
+++ b/src/Elara/AST/Typed.hs
@@ -74,8 +74,6 @@ type instance Select (ASTType ForValueDecl) 'Typed = Type SourceRegion
 
 type instance Select ValueTypeDef 'Typed = DataConCantHappen
 
-type instance Select InfixDecl 'Typed = DataConCantHappen
-
 type instance Select Alias 'Typed = (Type SourceRegion, ElaraKind)
 
 type instance Select ADTParam 'Typed = (Monotype SourceRegion, ElaraKind)

--- a/src/Elara/AST/Typed.hs
+++ b/src/Elara/AST/Typed.hs
@@ -95,7 +95,8 @@ type instance Select UserDefinedType 'Typed = Qualified TypeName
 
 type instance Select ConstructorName 'Typed = Qualified TypeName
 
-type instance Select (Annotations a) 'Typed = NoFieldValue
+type instance Select AnnotationName 'Typed = Qualified TypeName
+type instance Select (Annotations a) 'Typed = [Generic.Annotation 'Typed]
 
 type TypedExpr = Generic.Expr 'Typed
 

--- a/src/Elara/AST/Unlocated.hs
+++ b/src/Elara/AST/Unlocated.hs
@@ -6,7 +6,7 @@ module Elara.AST.Unlocated where
 import Data.Kind qualified as Kind
 import Elara.AST.Generic
 import Elara.AST.Region (Located)
-import Elara.AST.Select (LocatedAST (..), UnlocatedAST (..))
+import Elara.AST.Select (LocatedAST (..), UnlocatedAST (..), UnlocatedToLocated)
 import Elara.AST.VarRef (UnlocatedVarRef, VarRef)
 import Elara.Data.Unique (Unique)
 
@@ -20,15 +20,17 @@ type instance ASTLocate' 'UnlocatedShunted = Unlocated
 
 type instance ASTLocate' 'UnlocatedTyped = Unlocated
 
-type instance Select any 'UnlocatedFrontend = Replace 'Frontend 'UnlocatedFrontend (Select any 'Frontend)
+type instance Select any ast = Replace (UnlocatedToLocated ast) ast (Select any (UnlocatedToLocated ast))
 
-type instance Select any 'UnlocatedDesugared = Replace 'Desugared 'UnlocatedDesugared (Select any 'Desugared)
+-- type instance Select any 'UnlocatedFrontend = Replace 'Frontend 'UnlocatedFrontend (Select any 'Frontend)
 
-type instance Select any 'UnlocatedRenamed = Replace 'Renamed 'UnlocatedRenamed (Select any 'Renamed)
+-- type instance Select any 'UnlocatedDesugared = Replace 'Desugared 'UnlocatedDesugared (Select any 'Desugared)
 
-type instance Select any 'UnlocatedShunted = Replace 'Shunted 'UnlocatedShunted (Select any 'Shunted)
+-- type instance Select any 'UnlocatedRenamed = Replace 'Renamed 'UnlocatedRenamed (Select any 'Renamed)
 
-type instance Select any 'UnlocatedTyped = Replace 'Typed 'UnlocatedTyped (Select any 'Typed)
+-- type instance Select any 'UnlocatedShunted = Replace 'Shunted 'UnlocatedShunted (Select any 'Shunted)
+
+-- type instance Select any 'UnlocatedTyped = Replace 'Typed 'UnlocatedTyped (Select any 'Typed)
 
 type family Replace (needle :: LocatedAST) (replacement :: UnlocatedAST) (haystack :: Kind.Type) where
     Replace _ _ (VarRef a) = UnlocatedVarRef a -- This doesn't really belong here but it's easier than putting it elsewhere

--- a/src/Elara/ConstExpr.hs
+++ b/src/Elara/ConstExpr.hs
@@ -1,0 +1,26 @@
+-- | A teeny tiny interpreter for evaluating constant expressions, eg annotation values
+module Elara.ConstExpr where
+
+import Effectful
+import Elara.AST.Generic (AnnotationArg (..), Expr (..), Expr' (..), RUnlocate (..))
+import Elara.AST.Region
+
+data ConstVal
+    = ConstInt Integer
+    | ConstString Text
+    | ConstChar Char
+    | ConstUnit
+    deriving (Show, Eq)
+
+interpretAnnotationArg :: RUnlocate ast => AnnotationArg ast -> Eff r ConstVal
+interpretAnnotationArg (AnnotationArg e) = interpretAnnotationArg' e
+
+interpretAnnotationArg' :: forall ast r. RUnlocate ast => Expr ast -> Eff r ConstVal
+interpretAnnotationArg' (Expr (le, _)) = interpretAnnotationArg'' (le ^. rUnlocated @_ @ast @(Expr' ast))
+
+interpretAnnotationArg'' :: Expr' ast -> Eff r ConstVal
+interpretAnnotationArg'' (Int n) = pure $ ConstInt n
+interpretAnnotationArg'' (String s) = pure $ ConstString s
+interpretAnnotationArg'' (Char c) = pure $ ConstChar c
+interpretAnnotationArg'' Unit = pure ConstUnit
+interpretAnnotationArg'' other = error "Non-constant expression in annotation: " -- TODO

--- a/src/Elara/Desugar.hs
+++ b/src/Elara/Desugar.hs
@@ -28,6 +28,7 @@ import Elara.Utils (curry3)
 import Optics (traverseOf_)
 import Rock qualified
 import Rock.Memo (MemoQuery (MemoQuery))
+import TODO (todo)
 import Unsafe.Coerce (unsafeCoerce)
 import Prelude hiding (Op)
 
@@ -51,10 +52,9 @@ resolvePartialDeclaration ((AllDecl n sr ty e ann)) =
         ( DeclarationBody
             (Located sr (Value n e NoFieldValue (Just ty) ann))
         )
-resolvePartialDeclaration (JustInfix n sr v) = throwError (InfixWithoutDeclaration n sr v)
 
 resolveAnn :: Maybe (ValueDeclAnnotations Desugared) -> ValueDeclAnnotations Desugared
-resolveAnn = fromMaybe (ValueDeclAnnotations NoFieldValue)
+resolveAnn = fromMaybe (ValueDeclAnnotations undefined)
 
 getDesugaredModule ::
     ModuleName ->
@@ -87,30 +87,19 @@ desugarDeclarations mn decls = do
 assertPartialNamesEqual :: Eq a => (PartialDeclaration, Located a) -> (PartialDeclaration, Located a) -> Desugar ()
 assertPartialNamesEqual (p1, n1) (p2, n2) = if n1 ^. unlocated == n2 ^. unlocated then pass else throwError (PartialNamesNotEqual p1 p2)
 
-resolveDupeInfixes :: Maybe (ValueDeclAnnotations Desugared) -> Maybe (ValueDeclAnnotations Desugared) -> Desugar (ValueDeclAnnotations Desugared)
-resolveDupeInfixes (Just (ValueDeclAnnotations _)) (Just (ValueDeclAnnotations _)) = pure (ValueDeclAnnotations NoFieldValue)
-resolveDupeInfixes a b = pure (fromMaybe (ValueDeclAnnotations NoFieldValue) (a <|> b))
+mergeAnnotations :: Maybe (ValueDeclAnnotations Desugared) -> Maybe (ValueDeclAnnotations Desugared) -> Desugar (ValueDeclAnnotations Desugared)
+mergeAnnotations (Just (ValueDeclAnnotations as)) (Just (ValueDeclAnnotations bs)) =
+    pure (ValueDeclAnnotations (as <> bs))
+mergeAnnotations a b = pure (fromMaybe (ValueDeclAnnotations todo) (a <|> b))
 
 mergePartials :: PartialDeclaration -> PartialDeclaration -> Desugar PartialDeclaration
-mergePartials p1@(JustInfix n sr i) p2@(JustDef n' sr' ty Nothing) = do
-    assertPartialNamesEqual (p1, n) (p2, NVarName <$> n')
-    pure (JustDef n' (sr <> sr') ty (Just i))
-mergePartials p2@(JustDef n' sr' ty Nothing) p1@(JustInfix n sr i) = do
-    assertPartialNamesEqual (p1, n) (p2, NVarName <$> n')
-    pure (JustDef n' (sr <> sr') ty (Just i))
-mergePartials p1@(JustInfix n sr i) p2@(JustLet n' sr' ty Nothing) = do
-    assertPartialNamesEqual (p1, n) (p2, NVarName <$> n')
-    pure (JustLet n' (sr <> sr') ty (Just i))
-mergePartials p2@(JustLet n' sr' ty Nothing) p1@(JustInfix n sr i) = do
-    assertPartialNamesEqual (p1, n) (p2, NVarName <$> n')
-    pure (JustLet n' (sr <> sr') ty (Just i))
 mergePartials p1@(JustDef n sr ty mAnn) p2@(JustLet n' sr' e mAnn') = do
     assertPartialNamesEqual (p1, n) (p2, n')
-    ann <- resolveDupeInfixes mAnn mAnn'
+    ann <- mergeAnnotations mAnn mAnn'
     pure (AllDecl n' (sr <> sr') ty e ann)
 mergePartials p1@(JustLet n sr e mAnn) p2@(JustDef n' sr' ty mAnn') = do
     assertPartialNamesEqual (p1, n) (p2, n')
-    ann <- resolveDupeInfixes mAnn mAnn'
+    ann <- mergeAnnotations mAnn mAnn'
     pure (AllDecl n' (sr <> sr') ty e ann)
 mergePartials l r = throwError (DuplicateDeclaration l r)
 
@@ -134,21 +123,28 @@ genPartials = traverseOf_ (each % _Unwrapped) genPartial
             exp' <- desugarExpr e
             pats' <- traverse desugarPattern pats
             let body = foldLambda pats' exp'
-            let ann = coerceValueDeclAnnotations @Frontend @Desugared valueAnnotations
+            ann <- traverseValueDeclAnnotations desugarAnnotation valueAnnotations
 
             pure (JustLet n wholeDeclRegion body (Just ann))
-        genPartial'' (ValueTypeDef n ty _) = do
+        genPartial'' (ValueTypeDef n ty annotations) = do
             ty' <- traverseOf (_Unwrapped % _1 % unlocated) desugarType ty
-            pure (JustDef n wholeDeclRegion ty' Nothing)
+            ann <- traverseValueDeclAnnotations desugarAnnotation annotations
+            pure (JustDef n wholeDeclRegion ty' (Just ann))
         genPartial'' (TypeDeclaration n vars typeDecl typeAnnotations) = do
             let traverseDecl :: FrontendTypeDeclaration -> Desugar DesugaredTypeDeclaration
                 traverseDecl (Alias t) = Alias <$> traverseOf (_Unwrapped % _1 % unlocated) desugarType t
                 traverseDecl (ADT constructors) = ADT <$> traverseOf (each % _2 % each % _Unwrapped % _1 % unlocated) desugarType constructors
             typeDecl' <- traverseOf unlocated traverseDecl typeDecl
-            let ann = coerceTypeDeclAnnotations @Frontend @Desugared typeAnnotations
+            ann <- traverseTypeDeclAnnotations desugarAnnotation typeAnnotations
             let decl' = TypeDeclaration n vars typeDecl' ann
             let bodyLoc = decl ^. the @"body" % _Unwrapped % sourceRegion
             pure (Immediate (n ^. unlocated % to NTypeName) (DeclarationBody (Located bodyLoc decl')))
+
+desugarAnnotation :: Annotation Frontend -> Desugar (Annotation Desugared)
+desugarAnnotation (Annotation n args) = Annotation n <$> traverse desugarAnnotationArg args
+
+desugarAnnotationArg :: AnnotationArg Frontend -> Desugar (AnnotationArg Desugared)
+desugarAnnotationArg (AnnotationArg e) = AnnotationArg <$> desugarExpr e
 
 desugarType :: FrontendType' -> Desugar DesugaredType'
 desugarType x = pure (unsafeCoerce x)

--- a/src/Elara/Desugar.hs
+++ b/src/Elara/Desugar.hs
@@ -54,7 +54,7 @@ resolvePartialDeclaration ((AllDecl n sr ty e ann)) =
 resolvePartialDeclaration (JustInfix n sr v) = throwError (InfixWithoutDeclaration n sr v)
 
 resolveAnn :: Maybe (ValueDeclAnnotations Desugared) -> ValueDeclAnnotations Desugared
-resolveAnn = fromMaybe (ValueDeclAnnotations Nothing)
+resolveAnn = fromMaybe (ValueDeclAnnotations Nothing NoFieldValue)
 
 getDesugaredModule ::
     ModuleName ->
@@ -88,9 +88,9 @@ assertPartialNamesEqual :: Eq a => (PartialDeclaration, Located a) -> (PartialDe
 assertPartialNamesEqual (p1, n1) (p2, n2) = if n1 ^. unlocated == n2 ^. unlocated then pass else throwError (PartialNamesNotEqual p1 p2)
 
 resolveDupeInfixes :: Maybe (ValueDeclAnnotations Desugared) -> Maybe (ValueDeclAnnotations Desugared) -> Desugar (ValueDeclAnnotations Desugared)
-resolveDupeInfixes (Just a@(ValueDeclAnnotations (Just _))) (Just b@(ValueDeclAnnotations (Just _))) = throwError (DuplicateAnnotations a b)
-resolveDupeInfixes (Just (ValueDeclAnnotations a)) (Just (ValueDeclAnnotations b)) = pure (ValueDeclAnnotations (a <|> b))
-resolveDupeInfixes a b = pure (fromMaybe (ValueDeclAnnotations Nothing) (a <|> b))
+resolveDupeInfixes (Just a@(ValueDeclAnnotations (Just _) _)) (Just b@(ValueDeclAnnotations (Just _) _)) = throwError (DuplicateAnnotations a b)
+resolveDupeInfixes (Just (ValueDeclAnnotations a _)) (Just (ValueDeclAnnotations b _)) = pure (ValueDeclAnnotations (a <|> b) NoFieldValue)
+resolveDupeInfixes a b = pure (fromMaybe (ValueDeclAnnotations Nothing NoFieldValue) (a <|> b))
 
 mergePartials :: PartialDeclaration -> PartialDeclaration -> Desugar PartialDeclaration
 mergePartials p1@(JustInfix n sr i) p2@(JustDef n' sr' ty Nothing) = do
@@ -132,7 +132,7 @@ genPartials = traverseOf_ (each % _Unwrapped) genPartial
 
         genPartial'' :: FrontendDeclarationBody' -> Desugar PartialDeclaration
         genPartial'' (InfixDecl (InfixDeclaration n p a)) = do
-            let infix'' = ValueDeclAnnotations (Just (InfixDeclaration n p a))
+            let infix'' = ValueDeclAnnotations (Just (InfixDeclaration n p a)) NoFieldValue
 
             pure (JustInfix n wholeDeclRegion infix'')
         genPartial'' (Value n e pats _ valueAnnotations) = do

--- a/src/Elara/Desugar.hs
+++ b/src/Elara/Desugar.hs
@@ -137,7 +137,7 @@ genPartials = traverseOf_ (each % _Unwrapped) genPartial
             let ann = coerceValueDeclAnnotations @Frontend @Desugared valueAnnotations
 
             pure (JustLet n wholeDeclRegion body (Just ann))
-        genPartial'' (ValueTypeDef n ty) = do
+        genPartial'' (ValueTypeDef n ty _) = do
             ty' <- traverseOf (_Unwrapped % _1 % unlocated) desugarType ty
             pure (JustDef n wholeDeclRegion ty' Nothing)
         genPartial'' (TypeDeclaration n vars typeDecl typeAnnotations) = do

--- a/src/Elara/Desugar/Error.hs
+++ b/src/Elara/Desugar/Error.hs
@@ -89,10 +89,6 @@ data PartialDeclaration
         SourceRegion
         DesugaredExpr
         (Maybe (ValueDeclAnnotations Desugared))
-    | JustInfix
-        (Located Name)
-        SourceRegion
-        (ValueDeclAnnotations Desugared)
     | AllDecl (Located VarName) SourceRegion DesugaredType DesugaredExpr (ValueDeclAnnotations Desugared)
     | Immediate Name DesugaredDeclarationBody
     deriving (Typeable, Show, Generic)
@@ -100,13 +96,11 @@ data PartialDeclaration
 partialDeclarationSourceRegion :: PartialDeclaration -> SourceRegion
 partialDeclarationSourceRegion (JustDef _ sr _ _) = sr
 partialDeclarationSourceRegion (JustLet _ sr _ _) = sr
-partialDeclarationSourceRegion (JustInfix _ sr _) = sr
 partialDeclarationSourceRegion (AllDecl _ sr _ _ _) = sr
 partialDeclarationSourceRegion (Immediate _ (DeclarationBody (Located sr _))) = sr
 
 instance Pretty PartialDeclaration where
     pretty (JustDef n _ _ _) = "JustDef" <+> pretty n
     pretty (JustLet n _ _ _) = "JustLet" <+> pretty n
-    pretty (JustInfix n _ _) = "JustInfix" <+> pretty n
     pretty (AllDecl n _ _ _ _) = "All" <+> pretty n
     pretty (Immediate n _) = "Immediate" <+> pretty n

--- a/src/Elara/Desugar/Error.hs
+++ b/src/Elara/Desugar/Error.hs
@@ -16,7 +16,6 @@ data DesugarError
     = DefWithoutLet DesugaredType
     | InfixWithoutDeclaration (Located Name) SourceRegion (ValueDeclAnnotations Desugared)
     | DuplicateDeclaration PartialDeclaration PartialDeclaration
-    | DuplicateAnnotations (ValueDeclAnnotations Desugared) (ValueDeclAnnotations Desugared)
     | PartialNamesNotEqual PartialDeclaration PartialDeclaration
     | TuplePatternTooShort FrontendPattern
     deriving (Typeable, Show, Generic)
@@ -51,8 +50,6 @@ instance ReportableError DesugarError where
         Just $ Err (Just Codes.partialNamesNotEqual) ("Partial names not equal: " <+> pretty a <+> "and" <+> pretty b) [] []
     getReport (InfixWithoutDeclaration n _ l) =
         Just $ Err (Just Codes.infixDeclarationWithoutValue) ("Operator fixity declaration without corresponding body: " <+> pretty n <+> "," <+> show l) [] []
-    getReport (DuplicateAnnotations a b) =
-        Just $ Err (Just Codes.duplicateFixityAnnotations) ("Duplicate fixity annotations" <+> pretty a <+> "and" <+> pretty b) [] []
     getReport (TuplePatternTooShort p) =
         Just $
             Err

--- a/src/Elara/Desugar/Error.hs
+++ b/src/Elara/Desugar/Error.hs
@@ -98,7 +98,7 @@ data PartialDeclaration
         (ValueDeclAnnotations Desugared)
     | AllDecl (Located VarName) SourceRegion DesugaredType DesugaredExpr (ValueDeclAnnotations Desugared)
     | Immediate Name DesugaredDeclarationBody
-    deriving (Typeable, Show)
+    deriving (Typeable, Show, Generic)
 
 partialDeclarationSourceRegion :: PartialDeclaration -> SourceRegion
 partialDeclarationSourceRegion (JustDef _ sr _ _) = sr

--- a/src/Elara/Error/Internal.hs
+++ b/src/Elara/Error/Internal.hs
@@ -8,6 +8,8 @@ import Elara.AST.Name
 data InternalError
     = RequiredDeclNotFound (Qualified Name)
     | DuplicateDeclAfterDesugar ModuleName Name
+    | -- | When we parse an annotation at compile time but its arrangement is invalid
+      InvalidAnnotationArrangement
     deriving (Show, Eq)
 
 instance Exception InternalError

--- a/src/Elara/Error/Internal.hs
+++ b/src/Elara/Error/Internal.hs
@@ -1,0 +1,13 @@
+{- | Module for internal compiler errors.
+Unlike the stage-based errors, these errors indicate that something has gone wrong internally, eg an invariant has been violated.
+-}
+module Elara.Error.Internal where
+
+import Elara.AST.Name
+
+data InternalError
+    = RequiredDeclNotFound (Qualified Name)
+    | DuplicateDeclAfterDesugar ModuleName Name
+    deriving (Show, Eq)
+
+instance Exception InternalError

--- a/src/Elara/Lexer/Lexer.x
+++ b/src/Elara/Lexer/Lexer.x
@@ -93,12 +93,12 @@ tokens :-
       \' (. # [\'\\] | " " | @escape) \' { parametrizedTok TokenChar (read . toString) }
 
       -- Keywords
-      let					           { simpleTok TokenLet }
+      let					 { simpleTok TokenLet }
       def                    { simpleTok TokenDef }
       if                     { simpleTok TokenIf }
       then                   { simpleTok TokenThen }
       else                   { simpleTok TokenElse }
-      in					           { simpleTok TokenIn }
+      in					 { simpleTok TokenIn }
       match                  { simpleTok TokenMatch }
       with                   { simpleTok TokenWith }
       data                   { simpleTok TokenData }
@@ -134,7 +134,7 @@ tokens :-
       \"                     { beginString stringSC }
 
       -- Identifiers
-      @variableIdentifier     { parametrizedTok TokenVariableIdentifier identity}
+      @variableIdentifier    { parametrizedTok TokenVariableIdentifier identity}
       @typeIdentifier        { parametrizedTok TokenConstructorIdentifier identity}
       @opIdentifier          { parametrizedTok TokenOperatorIdentifier identity}
   

--- a/src/Elara/Lexer/Lexer.x
+++ b/src/Elara/Lexer/Lexer.x
@@ -118,6 +118,7 @@ tokens :-
       \-\>                   { simpleTok TokenRightArrow }
       \<\-                   { simpleTok TokenLeftArrow }
       \=\>                   { simpleTok TokenDoubleRightArrow }
+      \#                     { simpleTok TokenHash }
       \@                     { simpleTok TokenAt }
       \(                     { simpleTok TokenLeftParen }
       \)                     { simpleTok TokenRightParen }

--- a/src/Elara/Lexer/Lexer.x
+++ b/src/Elara/Lexer/Lexer.x
@@ -107,9 +107,6 @@ tokens :-
       alias                  { simpleTok TokenAlias }
       module                 { simpleTok TokenModule } 
       import                 { simpleTok TokenImport }
-      infixl                 { simpleTok TokenInfixL }
-      infixr                 { simpleTok TokenInfixR }
-      infix                  { simpleTok TokenInfix }
 
       -- Symbols
       \;                     { simpleTok TokenSemicolon }

--- a/src/Elara/Lexer/Token.hs
+++ b/src/Elara/Lexer/Token.hs
@@ -48,6 +48,8 @@ data Token
       TokenDoubleRightArrow
     | -- | @
       TokenAt
+    | -- | #
+      TokenHash
     | -- | `
       TokenBacktick
     | TokenInt Integer
@@ -114,6 +116,7 @@ tokenRepr = \case
     TokenRightArrow -> "->"
     TokenDoubleRightArrow -> "=>"
     TokenAt -> "@"
+    TokenHash -> "#"
     TokenBacktick -> "`"
     TokenInt i -> show i
     TokenFloat f -> show f
@@ -200,7 +203,7 @@ tokenEndsExpr = \case
     TokenDoubleColon -> False
     TokenDot -> False
     TokenIndent -> False
-    -- important: decent does end an expression because it closes a block
+    -- important: dedent does end an expression because it closes a block
     TokenDedent -> True
     -- everything else ends an expression:
     -- identifiers (var/ctor/qualified), literals, keywords, closers, LINESEP, EOF, etc.

--- a/src/Elara/Lexer/Token.hs
+++ b/src/Elara/Lexer/Token.hs
@@ -78,9 +78,6 @@ data Token
     | TokenDeriving
     | TokenMatch
     | TokenWith
-    | TokenInfixL
-    | TokenInfixR
-    | TokenInfix
     | -- | Variable Identifiers
       TokenVariableIdentifier Text
     | TokenConstructorIdentifier Text
@@ -145,9 +142,6 @@ tokenRepr = \case
     TokenDeriving -> "deriving"
     TokenMatch -> "match"
     TokenWith -> "with"
-    TokenInfixL -> "infixl"
-    TokenInfixR -> "infixr"
-    TokenInfix -> "infix"
     TokenVariableIdentifier i -> i
     TokenConstructorIdentifier i -> i
     TokenOperatorIdentifier i -> i

--- a/src/Elara/Parse/Annotation.hs
+++ b/src/Elara/Parse/Annotation.hs
@@ -1,0 +1,67 @@
+module Elara.Parse.Annotation where
+
+import Elara.AST.Frontend (FrontendExpr, FrontendExpr')
+import Elara.AST.Generic.Types (Annotation (..), AnnotationArg (..), Expr (..), Expr' (..))
+import Elara.AST.Region (Located (..))
+import Elara.AST.Select
+import Elara.Lexer.Token (Token (..))
+import Elara.Parse.Error (ElaraParseError (..))
+import Elara.Parse.Expression (expression)
+import Elara.Parse.Indents (lineSeparator)
+import Elara.Parse.Names (conName)
+import Elara.Parse.Primitives
+import Text.Megaparsec (customFailure)
+
+annotations :: Parser [Annotation 'Frontend]
+annotations = many annotation
+
+annotation :: Parser (Annotation 'Frontend)
+annotation = do
+    token_ TokenHash
+    annName <- located conName
+
+    args <- many constExpr
+
+    void $ optional lineSeparator -- if the annotation ends with a new line
+    pure (Annotation annName args)
+
+constExpr :: Parser (AnnotationArg Frontend)
+constExpr = do
+    e <- expression
+    validateConstExpr e
+
+validateConstExpr :: FrontendExpr -> Parser (AnnotationArg Frontend)
+validateConstExpr e = validateConstExpr' e
+  where
+    validateConstExpr' :: FrontendExpr -> Parser (AnnotationArg Frontend)
+    validateConstExpr' focus@(Expr (Located _ x, _)) = validateConstExpr'' focus x
+
+    validateConstExpr'' :: FrontendExpr -> FrontendExpr' -> Parser (AnnotationArg Frontend)
+    validateConstExpr'' var (Var _) = customFailure (InvalidConstantExpression e var)
+    validateConstExpr'' lam (Lambda{}) = customFailure (InvalidConstantExpression e lam)
+    validateConstExpr'' if' (If{}) = customFailure (InvalidConstantExpression e if')
+    validateConstExpr'' bin (BinaryOperator{}) = customFailure (InvalidConstantExpression e bin)
+    validateConstExpr'' match (Match{}) = customFailure (InvalidConstantExpression e match)
+    validateConstExpr'' let' (Let{}) = customFailure (InvalidConstantExpression e let')
+    validateConstExpr'' let' (LetIn{}) = customFailure (InvalidConstantExpression e let')
+    validateConstExpr'' block (Block{}) = customFailure (InvalidConstantExpression e block)
+    validateConstExpr'' app (TypeApplication{}) = customFailure (InvalidConstantExpression e app)
+    validateConstExpr'' int (Int{}) = pure (AnnotationArg int)
+    validateConstExpr'' float (Float{}) = pure (AnnotationArg float)
+    validateConstExpr'' string (String{}) = pure (AnnotationArg string)
+    validateConstExpr'' char (Char{}) = pure (AnnotationArg char)
+    validateConstExpr'' unit Unit{} = pure (AnnotationArg unit)
+    validateConstExpr'' con Constructor{} = pure (AnnotationArg con)
+    validateConstExpr'' func (FunctionCall a b) = do
+        void $ validateConstExpr' a
+        void $ validateConstExpr' b
+        pure (AnnotationArg func) -- just validating
+    validateConstExpr'' list (List elems) = do
+        traverse_ validateConstExpr' elems
+        pure (AnnotationArg list)
+    validateConstExpr'' tuple (Tuple elems) = do
+        traverse_ validateConstExpr' elems
+        pure (AnnotationArg tuple)
+    validateConstExpr'' inParens (InParens e) = do
+        void $ validateConstExpr' e
+        pure (AnnotationArg inParens)

--- a/src/Elara/Parse/Declaration.hs
+++ b/src/Elara/Parse/Declaration.hs
@@ -46,7 +46,7 @@ letDec :: Located ModuleName -> Parser FrontendDeclaration
 letDec modName = fmapLocated Declaration $ do
     (name, patterns, e) <- letPreamble
     let valueLocation = sconcat (e ^. _Unwrapped % _1 % sourceRegion :| (view (_Unwrapped % _1 % sourceRegion) <$> patterns))
-        annotations = ValueDeclAnnotations Nothing
+        annotations = ValueDeclAnnotations Nothing NoFieldValue
         value = DeclarationBody (Located valueLocation (Value name e patterns NoFieldValue annotations))
     pure (Declaration' modName value)
 
@@ -60,7 +60,7 @@ typeDeclaration modName = fmapLocated Declaration $ ignoringIndents $ do
     token_ TokenEquals
     body <- located (if isAlias then alias else adt)
     let valueLocation = name ^. sourceRegion <> body ^. sourceRegion
-        annotations = TypeDeclAnnotations Nothing NoFieldValue
+        annotations = TypeDeclAnnotations Nothing NoFieldValue NoFieldValue
         value = DeclarationBody $ Located valueLocation (TypeDeclaration name args body annotations)
     pure (Declaration' modName value)
 

--- a/src/Elara/Parse/Declaration.hs
+++ b/src/Elara/Parse/Declaration.hs
@@ -4,15 +4,13 @@ import Data.Generics.Wrapped
 import Elara.AST.Frontend (FrontendDeclaration, FrontendTypeDeclaration)
 import Elara.AST.Generic
 import Elara.AST.Generic.Common
-import Elara.AST.Name (ModuleName, ToName (..))
+import Elara.AST.Name (ModuleName)
 import Elara.AST.Region
 import Elara.Lexer.Token (Token (..))
 import Elara.Parse.Combinators (sepBy1')
-import Elara.Parse.Error
-import Elara.Parse.Expression (letPreamble, operator)
-import Elara.Parse.Literal (integerLiteral)
+import Elara.Parse.Expression (letPreamble)
 import Elara.Parse.Names
-import Elara.Parse.Primitives (Parser, fmapLocated, ignoringIndents, located, token, token_, withPredicate)
+import Elara.Parse.Primitives (Parser, fmapLocated, ignoringIndents, located, token_)
 import Elara.Parse.Type (type', typeNotApplication)
 import Text.Megaparsec (choice)
 
@@ -22,7 +20,6 @@ declaration n =
         [ letDec n
         , defDec n
         , typeDeclaration n
-        , infixDecl n
         ]
 
 defDec :: Located ModuleName -> Parser FrontendDeclaration
@@ -46,7 +43,7 @@ letDec :: Located ModuleName -> Parser FrontendDeclaration
 letDec modName = fmapLocated Declaration $ do
     (name, patterns, e) <- letPreamble
     let valueLocation = sconcat (e ^. _Unwrapped % _1 % sourceRegion :| (view (_Unwrapped % _1 % sourceRegion) <$> patterns))
-        annotations = ValueDeclAnnotations Nothing NoFieldValue
+        annotations = ValueDeclAnnotations NoFieldValue
         value = DeclarationBody (Located valueLocation (Value name e patterns NoFieldValue annotations))
     pure (Declaration' modName value)
 
@@ -60,24 +57,8 @@ typeDeclaration modName = fmapLocated Declaration $ ignoringIndents $ do
     token_ TokenEquals
     body <- located (if isAlias then alias else adt)
     let valueLocation = name ^. sourceRegion <> body ^. sourceRegion
-        annotations = TypeDeclAnnotations Nothing NoFieldValue NoFieldValue
+        annotations = TypeDeclAnnotations NoFieldValue NoFieldValue
         value = DeclarationBody $ Located valueLocation (TypeDeclaration name args body annotations)
-    pure (Declaration' modName value)
-
-infixDecl :: Located ModuleName -> Parser FrontendDeclaration
-infixDecl modName = fmapLocated Declaration $ do
-    assoc <- located (LeftAssoc <$ token TokenInfixL <|> RightAssoc <$ token TokenInfixR <|> NonAssoc <$ token TokenInfix)
-    prec <-
-        withPredicate
-            (\prec -> (prec ^. unlocated) >= 0 && (prec ^. unlocated) <= 10)
-            InfixPrecTooHigh
-            (located integerLiteral)
-    name <- located operator
-    let valueLocation = sconcat (assoc ^. sourceRegion :| [prec ^. sourceRegion, name ^. sourceRegion])
-        value = DeclarationBody $ Located valueLocation (InfixDecl $ InfixDeclaration declName (fromInteger <$> prec) assoc)
-        declName = case name ^. unlocated of
-            MkBinaryOperator (Located _ (SymOp sym)) -> toName <$> sym
-            MkBinaryOperator (Located _ (Infixed x)) -> toName <$> x
     pure (Declaration' modName value)
 
 -- | ADT declarations

--- a/src/Elara/Parse/Declaration.hs
+++ b/src/Elara/Parse/Declaration.hs
@@ -6,25 +6,28 @@ import Elara.AST.Generic
 import Elara.AST.Generic.Common
 import Elara.AST.Name (ModuleName)
 import Elara.AST.Region
+import Elara.AST.Select
 import Elara.Lexer.Token (Token (..))
+import Elara.Parse.Annotation (annotations)
 import Elara.Parse.Combinators (sepBy1')
 import Elara.Parse.Expression (letPreamble)
 import Elara.Parse.Names
 import Elara.Parse.Primitives (Parser, fmapLocated, ignoringIndents, located, token_)
 import Elara.Parse.Type (type', typeNotApplication)
-import Text.Megaparsec (choice)
+import Text.Megaparsec (choice, try)
 
 declaration :: Located ModuleName -> Parser FrontendDeclaration
-declaration n =
+declaration n = do
+    annotations <- annotations
     choice
-        [ letDec n
-        , defDec n
-        , typeDeclaration n
+        [ letDec n annotations
+        , defDec n annotations
+        , typeDeclaration n annotations
         ]
 
-defDec :: Located ModuleName -> Parser FrontendDeclaration
-defDec modName = fmapLocated Declaration $ do
-    token_ TokenDef
+defDec :: Located ModuleName -> [Annotation 'Frontend] -> Parser FrontendDeclaration
+defDec modName annotations = fmapLocated Declaration $ do
+    try (token_ TokenDef)
 
     name <- located unqualifiedVarName
 
@@ -32,24 +35,25 @@ defDec modName = fmapLocated Declaration $ do
     typeAnnotation <- type'
 
     let annotationLocation = view sourceRegion name <> view (_Unwrapped % _1 % sourceRegion) typeAnnotation
-    let declBody = Located annotationLocation $ ValueTypeDef name typeAnnotation
+    let annotations' = ValueDeclAnnotations annotations
+    let declBody = Located annotationLocation $ ValueTypeDef name typeAnnotation annotations'
     pure
         ( Declaration'
             modName
             (DeclarationBody declBody)
         )
 
-letDec :: Located ModuleName -> Parser FrontendDeclaration
-letDec modName = fmapLocated Declaration $ do
+letDec :: Located ModuleName -> [Annotation 'Frontend] -> Parser FrontendDeclaration
+letDec modName annotations = fmapLocated Declaration $ do
     (name, patterns, e) <- letPreamble
     let valueLocation = sconcat (e ^. _Unwrapped % _1 % sourceRegion :| (view (_Unwrapped % _1 % sourceRegion) <$> patterns))
-        annotations = ValueDeclAnnotations NoFieldValue
-        value = DeclarationBody (Located valueLocation (Value name e patterns NoFieldValue annotations))
+        annotations' = ValueDeclAnnotations annotations
+        value = DeclarationBody (Located valueLocation (Value name e patterns NoFieldValue annotations'))
     pure (Declaration' modName value)
 
-typeDeclaration :: Located ModuleName -> Parser FrontendDeclaration
-typeDeclaration modName = fmapLocated Declaration $ ignoringIndents $ do
-    token_ TokenType
+typeDeclaration :: Located ModuleName -> [Annotation 'Frontend] -> Parser FrontendDeclaration
+typeDeclaration modName annotations = fmapLocated Declaration $ ignoringIndents $ do
+    try (token_ TokenType)
 
     isAlias <- isJust <$> optional (token_ TokenAlias)
     name <- located conId
@@ -57,8 +61,8 @@ typeDeclaration modName = fmapLocated Declaration $ ignoringIndents $ do
     token_ TokenEquals
     body <- located (if isAlias then alias else adt)
     let valueLocation = name ^. sourceRegion <> body ^. sourceRegion
-        annotations = TypeDeclAnnotations NoFieldValue NoFieldValue
-        value = DeclarationBody $ Located valueLocation (TypeDeclaration name args body annotations)
+        annotations' = TypeDeclAnnotations NoFieldValue annotations
+        value = DeclarationBody $ Located valueLocation (TypeDeclaration name args body annotations')
     pure (Declaration' modName value)
 
 -- | ADT declarations

--- a/src/Elara/Parse/Error.hs
+++ b/src/Elara/Parse/Error.hs
@@ -9,6 +9,7 @@ module Elara.Parse.Error where
 import Data.Foldable (Foldable (foldl))
 import Data.List (lines)
 import Data.Set qualified as Set (toList)
+import Elara.AST.Frontend (FrontendExpr)
 import Elara.AST.Name (MaybeQualified, VarName)
 import Elara.AST.Region (Located, SourceRegion, sourceRegion, sourceRegionToDiagnosePosition, unlocated)
 import Elara.Data.Pretty
@@ -18,6 +19,7 @@ import Elara.Lexer.Token (Lexeme)
 import Elara.Parse.Stream (TokenStream)
 import Error.Diagnose
 import Error.Diagnose.Compat.Megaparsec (HasHints (..))
+import TODO (todo)
 import Text.Megaparsec (unPos)
 import Text.Megaparsec qualified as MP
 import Text.Megaparsec.Error
@@ -28,6 +30,7 @@ data ElaraParseError
     | EmptyRecord SourceRegion
     | EmptyLambda SourceRegion
     | InfixPrecTooHigh (Located Integer)
+    | InvalidConstantExpression {wholeExpr :: FrontendExpr, offendingSection :: FrontendExpr}
     deriving (Eq, Show, Ord)
 
 parseErrorSources :: ElaraParseError -> [SourceRegion]
@@ -35,6 +38,7 @@ parseErrorSources (KeywordUsedAsName l) = [view sourceRegion l]
 parseErrorSources (EmptyRecord sr) = [sr]
 parseErrorSources (EmptyLambda sr) = [sr]
 parseErrorSources (InfixPrecTooHigh l) = [view sourceRegion l]
+parseErrorSources (InvalidConstantExpression a b) = [todo]
 
 instance HasHints ElaraParseError (Doc AnsiStyle) where
     hints (KeywordUsedAsName kw) =

--- a/src/Elara/Prim.hs
+++ b/src/Elara/Prim.hs
@@ -68,6 +68,19 @@ primitiveVars = [fetchPrimitiveName]
 primitiveTypes :: [TypeName]
 primitiveTypes = [stringName, charName, intName, consName]
 
+fixityAnnotationName :: Qualified TypeName
+fixityAnnotationName = mkPrimQual (TypeName "Fixity")
+
+associativityAnnotationName :: Qualified TypeName
+associativityAnnotationName = mkPrimQual (TypeName "Associativity")
+
+leftAssociativeAnnotationName :: Qualified TypeName
+leftAssociativeAnnotationName = mkPrimQual (TypeName "LeftAssociative")
+rightAssociativeAnnotationName :: Qualified TypeName
+rightAssociativeAnnotationName = mkPrimQual (TypeName "RightAssociative")
+nonAssociativeAnnotationName :: Qualified TypeName
+nonAssociativeAnnotationName = mkPrimQual (TypeName "NonAssociative")
+
 primKindCheckContext :: Map (Qualified TypeName) ElaraKind
 primKindCheckContext =
     -- assume all primitive types are kind Type

--- a/src/Elara/Query.hs
+++ b/src/Elara/Query.hs
@@ -49,7 +49,6 @@ import Elara.Lexer.Token
 import Elara.Lexer.Utils (LexerError)
 import Elara.Parse.Error (ElaraParseError, WParseErrorBundle)
 import Elara.Parse.Stream (TokenStream)
-import Elara.Query.Class
 import Elara.Query.Effects
 import Elara.Query.Errors
 import Elara.ReadFile (FileContents)

--- a/src/Elara/Query/Common.hs
+++ b/src/Elara/Query/Common.hs
@@ -1,7 +1,7 @@
 module Elara.Query.Common where
 
-import qualified Elara.Query
-import qualified Rock
+import Elara.Query qualified
+import Rock qualified
 
 {- | Appends 'Rock' to a list of effects.
   This type mainly exists to avoid a cyclic import between this module and 'Elara.Query.Effects'

--- a/src/Elara/Query/Common.hs
+++ b/src/Elara/Query/Common.hs
@@ -1,0 +1,10 @@
+module Elara.Query.Common where
+
+import qualified Elara.Query
+import qualified Rock
+
+{- | Appends 'Rock' to a list of effects.
+  This type mainly exists to avoid a cyclic import between this module and 'Elara.Query.Effects'
+-}
+type WithRock effects =
+    Rock.Rock Elara.Query.Query ': effects

--- a/src/Elara/Query/Effects.hs
+++ b/src/Elara/Query/Effects.hs
@@ -24,6 +24,11 @@ type ConsMinimumQueryEffects :: [Effect] -> [Effect]
 type ConsMinimumQueryEffects es =
     Memoise ': Concurrent ': es
 
+type HasMinimumQueryEffects es =
+    ( Memoise :> es
+    , Concurrent :> es
+    )
+
 type StandardQueryEffects = ConsQueryEffects '[]
 
 -- | Standard effects that almost every query will use

--- a/src/Elara/Query/Errors.hs
+++ b/src/Elara/Query/Errors.hs
@@ -1,0 +1,13 @@
+module Elara.Query.Errors where
+
+import Effectful
+import Effectful.Error.Static
+import Elara.AST.Select
+import Elara.Desugar.Error
+import Elara.Rename.Error
+import Elara.Shunt.Error
+
+type family StandardQueryError ast :: [Effect] where
+    StandardQueryError Desugared = '[Error DesugarError]
+    StandardQueryError Renamed = '[Error RenameError]
+    StandardQueryError Shunted = '[Error ShuntError]

--- a/src/Elara/Query/TH.hs
+++ b/src/Elara/Query/TH.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+{-# HLINT ignore "Use id" #-}
+
+module Elara.Query.TH where
+
+import Effectful (Eff, (:>))
+import Effectful.Concurrent
+import Language.Haskell.TH as TH
+import Rock.MemoE (Memoise)
+
+toNames :: Con -> [(Name, Int)]
+toNames = \case
+    NormalC n _ -> [(n, 0 :: Int)]
+    RecC n fs -> [(n, length fs)]
+    InfixC _ n _ -> [(n, 2)]
+    ForallC _ _ c -> toNames c
+    GadtC ns fs _ -> [(n, length fs) | n <- ns]
+    RecGadtC ns fs _ -> [(n, length fs) | n <- ns]
+
+-- Generate: tagQuery :: forall es a. Query es a -> Int
+makeTag :: Name -> TH.Q [TH.Dec]
+makeTag tyName = do
+    info <- reify tyName
+    cons <- case info of
+        TH.TyConI (TH.DataD _ _ _ _ cs _) -> pure cs
+        TH.TyConI (TH.NewtypeD _ _ _ _ c _) -> pure [c]
+        _ -> fail "makeTag: expected data/newtype"
+    let names = concatMap toNames cons
+        mkPat (n, ar) = conP n (replicate ar wildP)
+        mkClause i na = clause [mkPat na] (normalB (litE (IntegerL (fromIntegral i)))) []
+    sig <- sigD (mkName "tagQuery") [t|forall es a. $(conT tyName) es a -> Int|]
+    fun <- funD (mkName "tagQuery") (zipWith mkClause [0 ..] names)
+    pure [sig, fun]
+
+makeWithMemoiseE :: Name -> TH.Q [TH.Dec]
+makeWithMemoiseE tyName = do
+    info <- reify tyName
+    cons <- case info of
+        TH.TyConI (TH.DataD _ _ _ _ cs _) -> pure cs
+        TH.TyConI (TH.NewtypeD _ _ _ _ c _) -> pure [c]
+        _ -> fail "makeWithMemoiseE: expected data/newtype"
+    -- withMemoiseE :: f es a -> ((Memoise :> es, Concurrent :> es) => Eff es a) -> Eff es a
+    let names = fst <$> concatMap toNames cons
+    let mkClause con = clause [recP con []] (normalB [|\k -> k|]) []
+    let fName = mkName ("withMemoiseE" <> nameBase tyName)
+    sig <- sigD fName [t|forall es a. $(conT tyName) es a -> ((Memoise :> es, Concurrent :> es) => Eff es a) -> Eff es a|]
+    fun <- funD fName $ map mkClause names
+    pure [sig, fun]

--- a/src/Elara/Rename/Error.hs
+++ b/src/Elara/Rename/Error.hs
@@ -1,7 +1,6 @@
 module Elara.Rename.Error where
 
 import Data.Generics.Product
-import Data.Generics.Sum (_As)
 import Data.Generics.Wrapped (_Unwrapped)
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map qualified as Map

--- a/src/Elara/Rules.hs
+++ b/src/Elara/Rules.hs
@@ -3,151 +3,87 @@
 
 module Elara.Rules where
 
-import Data.Generics.Product (HasField' (..))
-import Data.Generics.Wrapped (_Unwrapped)
 import Data.Text qualified as Text
 import Effectful
-import Effectful.Exception (throwIO)
 import Effectful.State.Static.Local qualified as Local
-import Effectful.Writer.Static.Local (runWriter)
-import Elara.AST.Generic.Types (ASTLocate, CleanupLocated, RUnlocate (..), Select, declaration'Name, declarationBodyName, declarationName)
-import Elara.AST.Module (Module, Module')
-import Elara.AST.Name (ModuleName (..), Name, Qualified (..), ToName)
-import Elara.AST.Region (Located, unlocated)
+import Elara.AST.Name (ModuleName (..), Qualified (..))
 import Elara.AST.Select
 import Elara.Core.LiftClosures (runGetClosureLiftedModuleQuery)
 import Elara.CoreToCore (runGetANFCoreModuleQuery, runGetFinalisedCoreModuleQuery, runGetOptimisedCoreModuleQuery)
 import Elara.Data.Pretty
 import Elara.Desugar (getDesugaredModule)
-import Elara.Desugar.Error
-import Elara.Error
-import Elara.Error.Internal
 import Elara.Lexer.Reader (getLexedFile)
 import Elara.Logging (debug)
 import Elara.Parse (getParsedFileQuery, getParsedModuleQuery)
 import Elara.Prim.Rename (primitiveRenameState)
 import Elara.Query
-import Elara.Query.Effects (HasMinimumQueryEffects)
 import Elara.ReadFile (getInputFiles, runGetFileContentsQuery)
 import Elara.Rename (getRenamedModule)
 import Elara.SCC (buildSCCs, runFreeVarsQuery, runReachableSubgraphQuery)
 import Elara.Settings (CompilerSettings, mainFile)
-import Elara.Shunt (runGetOpInfoQuery, runGetOpTableInQuery, runGetShuntedModuleQuery)
+import Elara.Shunt (runGetOpInfoQuery, runGetOpTableInQuery)
 import Elara.ToCore (runGetCoreModuleQuery, runGetDataConQuery, runGetTyConQuery)
 import Elara.TypeInfer (runGetTypeCheckedModuleQuery, runInferSCCQuery, runKindOfQuery, runTypeCheckedExprQuery, runTypeOfQuery)
-import Optics (filtered)
 import Print (showPretty)
 import Rock qualified
 import System.FilePath (takeFileName)
 
 rules :: HasCallStack => CompilerSettings -> Rock.Rules Query
-rules compilerSettings key = do
-    case key of
-        GetCompilerSettings -> pure compilerSettings
-        InputFiles -> inject getInputFiles
-        GetFileContents fp -> runGetFileContentsQuery fp
-        LexedFile fp -> inject $ getLexedFile fp
-        ParsedFile fp -> inject $ getParsedFileQuery fp
-        ModulePath (ModuleName ("Main" :| [])) -> do
-            pure (compilerSettings.mainFile ?: "source.elr") -- THIS IS BAD
-        ModulePath mn@(ModuleName nameParts) -> do
-            inputs <- Rock.fetch Elara.Query.InputFiles
+rules compilerSettings key = case key of
+    GetCompilerSettings -> pure compilerSettings
+    InputFiles -> inject getInputFiles
+    GetFileContents fp -> runGetFileContentsQuery fp
+    LexedFile fp -> inject $ getLexedFile fp
+    ParsedFile fp -> inject $ getParsedFileQuery fp
+    ModulePath (ModuleName ("Main" :| [])) -> do
+        pure (compilerSettings.mainFile ?: "source.elr") -- THIS IS BAD
+    ModulePath mn@(ModuleName nameParts) -> do
+        inputs <- Rock.fetch Elara.Query.InputFiles
 
-            -- search through the inputs for a file with a matching name
-            -- TODO: this is very scuffed and makes a LOT of assumptions
-            let matchingFiles =
-                    [ input
-                    | input <- toList inputs
-                    , Text.toLower (toText $ takeFileName input) == Text.toLower (last nameParts <> ".elr")
-                    ]
-            case matchingFiles of
-                [fp] -> pure fp
-                _ -> error $ "Ambiguous module name: " <> showPretty mn
-        ParsedModule mn -> inject $ getParsedModuleQuery mn
-        DesugaredModule mn -> inject $ getDesugaredModule mn
-        RenamedModule mn -> Local.evalState primitiveRenameState $ inject $ getRenamedModule mn
-        ModuleByName @ast mn -> query @QueryModuleByName @ast mn
-        DeclarationByName @ast name -> query @QueryDeclarationByName @ast name
-        RequiredDeclarationByName @ast name -> query @QueryRequiredDeclarationByName @ast name
-        GetOpInfo opName -> inject $ runGetOpInfoQuery opName
-        GetOpTableIn mn -> inject $ runGetOpTableInQuery mn
-        FreeVarsOf name -> inject $ runFreeVarsQuery name
-        ReachableSubgraphOf name -> inject $ runReachableSubgraphQuery name
-        GetSCCsOf name -> do
-            subgraph <- inject $ runReachableSubgraphQuery name
-            debug $ "Subgraph for " <> pretty name <> ": " <> pretty subgraph
-            pure $ buildSCCs subgraph
-        SCCKeyOf _ -> do
-            error "SCCKeyOf not implemented"
-        TypeCheckedModule mn -> inject $ runGetTypeCheckedModuleQuery mn
-        TypeCheckedExpr exprId -> inject $ runTypeCheckedExprQuery exprId
-        InferSCC sccKey -> inject $ runInferSCCQuery sccKey
-        TypeOf key -> inject $ runTypeOfQuery key
-        KindOf qtn -> inject $ runKindOfQuery qtn
-        GetCoreModule mn -> inject $ runGetCoreModuleQuery mn
-        GetTyCon qn -> inject $ runGetTyConQuery qn
-        GetDataCon qn -> inject $ runGetDataConQuery qn
-        GetOptimisedCoreModule mn -> inject $ runGetOptimisedCoreModuleQuery mn
-        GetANFCoreModule mn -> inject $ runGetANFCoreModuleQuery mn
-        GetClosureLiftedModule mn -> inject $ runGetClosureLiftedModuleQuery mn
-        GetFinalisedCoreModule mn -> inject $ runGetFinalisedCoreModuleQuery mn
+        -- search through the inputs for a file with a matching name
+        -- TODO: this is very scuffed and makes a LOT of assumptions
+        let matchingFiles =
+                [ input
+                | input <- toList inputs
+                , Text.toLower (toText $ takeFileName input) == Text.toLower (last nameParts <> ".elr")
+                ]
+        case matchingFiles of
+            [fp] -> pure fp
+            _ -> error $ "Ambiguous module name: " <> showPretty mn
+    ParsedModule mn -> inject $ getParsedModuleQuery mn
+    DesugaredModule mn -> inject $ getDesugaredModule mn
+    RenamedModule mn -> Local.evalState primitiveRenameState $ inject $ getRenamedModule mn
+    ModuleByName @ast mn -> query @QueryModuleByName @ast mn
+    DeclarationByName @ast name -> query @QueryDeclarationByName @ast name
+    RequiredDeclarationByName @ast name -> query @QueryRequiredDeclarationByName @ast name
+    ConstructorDeclaration @ast conRef -> query @QueryConstructorDeclaration @ast conRef
+    DeclarationAnnotations @ast name -> query @DeclarationAnnotations @ast name
+    DeclarationAnnotationsOfType @ast (name, annotationName) -> query @DeclarationAnnotationsOfType @ast (name, annotationName)
+    GetOpInfo opName -> inject $ runGetOpInfoQuery opName
+    GetOpTableIn mn -> inject $ runGetOpTableInQuery mn
+    FreeVarsOf name -> inject $ runFreeVarsQuery name
+    ReachableSubgraphOf name -> inject $ runReachableSubgraphQuery name
+    GetSCCsOf name -> do
+        subgraph <- inject $ runReachableSubgraphQuery name
+        debug $ "Subgraph for " <> pretty name <> ": " <> pretty subgraph
+        pure $ buildSCCs subgraph
+    SCCKeyOf _ -> do
+        error "SCCKeyOf not implemented"
+    TypeCheckedModule mn -> inject $ runGetTypeCheckedModuleQuery mn
+    TypeCheckedExpr exprId -> inject $ runTypeCheckedExprQuery exprId
+    InferSCC sccKey -> inject $ runInferSCCQuery sccKey
+    TypeOf key -> inject $ runTypeOfQuery key
+    KindOf qtn -> inject $ runKindOfQuery qtn
+    GetCoreModule mn -> inject $ runGetCoreModuleQuery mn
+    GetTyCon qn -> inject $ runGetTyConQuery qn
+    GetDataCon qn -> inject $ runGetDataConQuery qn
+    GetOptimisedCoreModule mn -> inject $ runGetOptimisedCoreModuleQuery mn
+    GetANFCoreModule mn -> inject $ runGetANFCoreModuleQuery mn
+    GetClosureLiftedModule mn -> inject $ runGetClosureLiftedModuleQuery mn
+    GetFinalisedCoreModule mn -> inject $ runGetFinalisedCoreModuleQuery mn
 
-instance
-    ( SupportsQuery QueryModuleByName ast
-    , HasMinimumQueryEffects (QueryEffectsOf QueryDeclarationByName ast)
-    , Rock.Rock Query :> QueryEffectsOf QueryDeclarationByName ast
-    , Typeable ast
-    , Subset
-        (QueryEffectsOf QueryModuleByName ast)
-        (QueryEffectsOf QueryDeclarationByName ast)
-    , QueryReturnTypeOf QueryModuleByName ast ~ Module ast
-    , ToName (Select (ASTName ForValueDecl) ast)
-    , ToName (Select (ASTName ForType) ast)
-    , RUnlocate ast
-    , -- TODO these are stupid and we should find a way to remove them
-      CleanupLocated (Located (Select (ASTName ForType) ast)) ~ Located (Select (ASTName ForType) ast)
-    , CleanupLocated (Located (Select (ASTName ForValueDecl) ast)) ~ Located (Select (ASTName ForValueDecl) ast)
-    ) =>
-    SupportsQuery QueryDeclarationByName ast
-    where
-    query (Qualified name modName) = do
-        mod :: Module ast <- Rock.fetch $ ModuleByName @ast modName
+instance SupportsQuery QueryConstructorDeclaration Shunted where
+    query qn@(Qualified typeName modName) = do
+        decl <- Rock.fetch $ ModuleByName @Shunted modName
 
-        let matchingBodies =
-                mod
-                    ^.. _Unwrapped @(Module ast) @(Module ast) @(ASTLocate ast (Module' ast))
-                    % rUnlocated @_ @ast @(Module' ast)
-                    % field' @"declarations"
-                    % each
-                    % filtered (\b -> b ^. (declarationName @ast) % (rUnlocated @_ @ast @Name) == name)
-
-        case matchingBodies of
-            [] -> pure Nothing
-            [decl] -> pure (Just decl)
-            _ -> throwIO $ DuplicateDeclAfterDesugar modName name
-
-instance
-    ( SupportsQuery QueryDeclarationByName ast
-    , Subset
-        (QueryEffectsOf QueryDeclarationByName ast)
-        (QueryEffectsOf QueryRequiredDeclarationByName ast)
-    , HasMinimumQueryEffects (QueryEffectsOf QueryRequiredDeclarationByName ast)
-    , Rock.Rock Query :> QueryEffectsOf QueryRequiredDeclarationByName ast
-    , Typeable ast
-    ) =>
-    SupportsQuery QueryRequiredDeclarationByName ast
-    where
-    query name = do
-        mDecl <- Rock.fetch $ DeclarationByName @ast name
-        case mDecl of
-            Just decl -> pure decl
-            Nothing -> throwIO $ RequiredDeclNotFound name
-
-instance SupportsQuery QueryModuleByName Shunted where
-    query mn = do
-        (mod, warnings) <- runWriter $ inject $ runGetShuntedModuleQuery mn
-        traverse_ report warnings
-        pure mod
-
-instance SupportsQuery QueryModuleByName Renamed where
-    query mn = Local.evalState primitiveRenameState $ inject $ getRenamedModule mn
+        error (showPretty decl)

--- a/src/Elara/Rules.hs
+++ b/src/Elara/Rules.hs
@@ -1,27 +1,41 @@
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE UndecidableInstances #-}
+
 module Elara.Rules where
 
+import Data.Generics.Product (HasField' (..))
+import Data.Generics.Wrapped (_Unwrapped)
 import Data.Text qualified as Text
 import Effectful
+import Effectful.Exception (throwIO)
 import Effectful.State.Static.Local qualified as Local
 import Effectful.Writer.Static.Local (runWriter)
-import Elara.AST.Name (ModuleName (..))
+import Elara.AST.Generic.Types (ASTLocate, CleanupLocated, RUnlocate (..), Select, declaration'Name, declarationBodyName, declarationName)
+import Elara.AST.Module (Module, Module')
+import Elara.AST.Name (ModuleName (..), Name, Qualified (..), ToName)
+import Elara.AST.Region (Located, unlocated)
+import Elara.AST.Select
 import Elara.Core.LiftClosures (runGetClosureLiftedModuleQuery)
 import Elara.CoreToCore (runGetANFCoreModuleQuery, runGetFinalisedCoreModuleQuery, runGetOptimisedCoreModuleQuery)
 import Elara.Data.Pretty
 import Elara.Desugar (getDesugaredModule)
+import Elara.Desugar.Error
 import Elara.Error
+import Elara.Error.Internal
 import Elara.Lexer.Reader (getLexedFile)
 import Elara.Logging (debug)
 import Elara.Parse (getParsedFileQuery, getParsedModuleQuery)
 import Elara.Prim.Rename (primitiveRenameState)
 import Elara.Query
+import Elara.Query.Effects (HasMinimumQueryEffects)
 import Elara.ReadFile (getInputFiles, runGetFileContentsQuery)
 import Elara.Rename (getRenamedModule)
 import Elara.SCC (buildSCCs, runFreeVarsQuery, runReachableSubgraphQuery)
 import Elara.Settings (CompilerSettings, mainFile)
-import Elara.Shunt (runGetOpInfoQuery, runGetOpTableInQuery, runGetShuntedModuleQuery, runShuntedDeclarationByNameQuery)
+import Elara.Shunt (runGetOpInfoQuery, runGetOpTableInQuery, runGetShuntedModuleQuery)
 import Elara.ToCore (runGetCoreModuleQuery, runGetDataConQuery, runGetTyConQuery)
 import Elara.TypeInfer (runGetTypeCheckedModuleQuery, runInferSCCQuery, runKindOfQuery, runTypeCheckedExprQuery, runTypeOfQuery)
+import Optics (filtered)
 import Print (showPretty)
 import Rock qualified
 import System.FilePath (takeFileName)
@@ -52,11 +66,9 @@ rules compilerSettings key = do
         ParsedModule mn -> inject $ getParsedModuleQuery mn
         DesugaredModule mn -> inject $ getDesugaredModule mn
         RenamedModule mn -> Local.evalState primitiveRenameState $ inject $ getRenamedModule mn
-        ShuntedModule mn -> do
-            (mod, warnings) <- runWriter $ inject $ runGetShuntedModuleQuery mn
-            traverse_ report warnings
-            pure mod
-        ShuntedDeclarationByName name -> inject $ runShuntedDeclarationByNameQuery name
+        ModuleByName @ast mn -> query @QueryModuleByName @ast mn
+        DeclarationByName @ast name -> query @QueryDeclarationByName @ast name
+        RequiredDeclarationByName @ast name -> query @QueryRequiredDeclarationByName @ast name
         GetOpInfo opName -> inject $ runGetOpInfoQuery opName
         GetOpTableIn mn -> inject $ runGetOpTableInQuery mn
         FreeVarsOf name -> inject $ runFreeVarsQuery name
@@ -79,3 +91,63 @@ rules compilerSettings key = do
         GetANFCoreModule mn -> inject $ runGetANFCoreModuleQuery mn
         GetClosureLiftedModule mn -> inject $ runGetClosureLiftedModuleQuery mn
         GetFinalisedCoreModule mn -> inject $ runGetFinalisedCoreModuleQuery mn
+
+instance
+    ( SupportsQuery QueryModuleByName ast
+    , HasMinimumQueryEffects (QueryEffectsOf QueryDeclarationByName ast)
+    , Rock.Rock Query :> QueryEffectsOf QueryDeclarationByName ast
+    , Typeable ast
+    , Subset
+        (QueryEffectsOf QueryModuleByName ast)
+        (QueryEffectsOf QueryDeclarationByName ast)
+    , QueryReturnTypeOf QueryModuleByName ast ~ Module ast
+    , ToName (Select (ASTName ForValueDecl) ast)
+    , ToName (Select (ASTName ForType) ast)
+    , RUnlocate ast
+    , -- TODO these are stupid and we should find a way to remove them
+      CleanupLocated (Located (Select (ASTName ForType) ast)) ~ Located (Select (ASTName ForType) ast)
+    , CleanupLocated (Located (Select (ASTName ForValueDecl) ast)) ~ Located (Select (ASTName ForValueDecl) ast)
+    ) =>
+    SupportsQuery QueryDeclarationByName ast
+    where
+    query (Qualified name modName) = do
+        mod :: Module ast <- Rock.fetch $ ModuleByName @ast modName
+
+        let matchingBodies =
+                mod
+                    ^.. _Unwrapped @(Module ast) @(Module ast) @(ASTLocate ast (Module' ast))
+                    % rUnlocated @_ @ast @(Module' ast)
+                    % field' @"declarations"
+                    % each
+                    % filtered (\b -> b ^. (declarationName @ast) % (rUnlocated @_ @ast @Name) == name)
+
+        case matchingBodies of
+            [] -> pure Nothing
+            [decl] -> pure (Just decl)
+            _ -> throwIO $ DuplicateDeclAfterDesugar modName name
+
+instance
+    ( SupportsQuery QueryDeclarationByName ast
+    , Subset
+        (QueryEffectsOf QueryDeclarationByName ast)
+        (QueryEffectsOf QueryRequiredDeclarationByName ast)
+    , HasMinimumQueryEffects (QueryEffectsOf QueryRequiredDeclarationByName ast)
+    , Rock.Rock Query :> QueryEffectsOf QueryRequiredDeclarationByName ast
+    , Typeable ast
+    ) =>
+    SupportsQuery QueryRequiredDeclarationByName ast
+    where
+    query name = do
+        mDecl <- Rock.fetch $ DeclarationByName @ast name
+        case mDecl of
+            Just decl -> pure decl
+            Nothing -> throwIO $ RequiredDeclNotFound name
+
+instance SupportsQuery QueryModuleByName Shunted where
+    query mn = do
+        (mod, warnings) <- runWriter $ inject $ runGetShuntedModuleQuery mn
+        traverse_ report warnings
+        pure mod
+
+instance SupportsQuery QueryModuleByName Renamed where
+    query mn = Local.evalState primitiveRenameState $ inject $ getRenamedModule mn

--- a/src/Elara/Rules/Generic.hs
+++ b/src/Elara/Rules/Generic.hs
@@ -1,0 +1,184 @@
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | AST agnostic implementations of rules
+module Elara.Rules.Generic where
+
+import Data.Generics.Product (HasField' (..))
+import Data.Generics.Wrapped (_Unwrapped)
+import Effectful
+import Effectful.Exception
+import Elara.AST.Generic.Types
+import Elara.AST.Introspection
+import Elara.AST.Module
+import Elara.AST.Name
+import Elara.AST.Region
+import Elara.AST.Select
+import Elara.Data.Pretty
+import Elara.Error.Internal
+import Elara.Query
+import Elara.Query.Effects
+import Elara.Query.Errors
+import Optics (filtered, has)
+import Rock qualified
+
+instance
+    ( SupportsQuery QueryModuleByName ast
+    , HasMinimumQueryEffects (QueryEffectsOf QueryDeclarationByName ast)
+    , Rock.Rock Query :> QueryEffectsOf QueryDeclarationByName ast
+    , Typeable ast
+    , RUnlocate ast
+    , Subset
+        (QueryEffectsOf QueryModuleByName ast)
+        (QueryEffectsOf QueryDeclarationByName ast)
+    , QueryReturnTypeOf QueryModuleByName ast ~ Module ast
+    , ToName (Select (ASTName ForValueDecl) ast)
+    , ToName (Select (ASTName ForType) ast)
+    , -- TODO these are stupid and we should find a way to remove them
+      CleanupLocated (Located (Select (ASTName ForType) ast)) ~ Located (Select (ASTName ForType) ast)
+    , CleanupLocated (Located (Select (ASTName ForValueDecl) ast)) ~ Located (Select (ASTName ForValueDecl) ast)
+    ) =>
+    SupportsQuery QueryDeclarationByName ast
+    where
+    type QuerySpecificEffectsOf QueryDeclarationByName ast = StandardQueryError ast
+    query (Qualified name modName) = do
+        mod :: Module ast <- Rock.fetch $ ModuleByName @ast modName
+
+        let matchingBodies =
+                mod
+                    ^.. _Unwrapped @(Module ast) @(Module ast) @(ASTLocate ast (Module' ast))
+                    % rUnlocated @_ @ast @(Module' ast)
+                    % field' @"declarations"
+                    % each
+                    % filtered (\b -> b ^. (declarationName @ast) % (rUnlocated @_ @ast @Name) == name)
+
+        case matchingBodies of
+            [] -> pure Nothing
+            [decl] -> pure (Just decl)
+            _ -> throwIO $ DuplicateDeclAfterDesugar modName name
+
+instance
+    ( HasMinimumQueryEffects (QueryEffectsOf QueryConstructorDeclaration ast)
+    , Select ConRef ast ~ Qualified TypeName
+    , Subset
+        (QueryEffectsOf QueryModuleByName ast)
+        (QueryEffectsOf QueryConstructorDeclaration ast)
+    , RUnlocate ast
+    , SupportsQuery QueryModuleByName ast
+    , Typeable ast
+    , Rock.Rock Query :> QueryEffectsOf QueryConstructorDeclaration ast
+    , Pretty (Select ADTParam ast)
+    , Pretty (ASTLocate ast (Select (ASTName ForType) ast))
+    , Pretty (ASTLocate ast (Select ASTTypeVar ast))
+    , Pretty (ASTLocate ast (TypeDeclaration ast))
+    , Pretty (ASTLocate ast (Declaration' ast))
+    , CleanupLocated (Located (Select ConstructorName ast)) ~ Located (Select ConstructorName ast)
+    , Select ConstructorName ast ~ Qualified TypeName
+    , QueryReturnTypeOf QueryConstructorDeclaration ast ~ Declaration ast
+    ) =>
+    SupportsQuery QueryConstructorDeclaration ast
+    where
+    query qn@(Qualified typeName modName) = do
+        mod <- Rock.fetch $ ModuleByName @ast modName
+        let matchingBodies =
+                mod
+                    ^.. _Unwrapped @(Module ast) @(Module ast) @(ASTLocate ast (Module' ast))
+                    % rUnlocated @_ @ast @(Module' ast)
+                    % field' @"declarations"
+                    % each
+                    % filtered
+                        ( has
+                            ( _Unwrapped
+                                % rUnlocated @_ @ast @(Declaration' ast)
+                                % field' @"body"
+                                % _Unwrapped
+                                % rUnlocated @_ @ast @(DeclarationBody' ast)
+                                % _Ctor' @"TypeDeclaration"
+                                % _3
+                                % rUnlocated @_ @ast @(TypeDeclaration ast)
+                                % _Ctor' @"ADT"
+                                % each
+                                % _1
+                                % rUnlocated @_ @ast @(Select ConstructorName ast)
+                                % filtered (== qn)
+                            )
+                        )
+        case matchingBodies of
+            [decl] -> pure decl
+            [] -> throwIO $ RequiredDeclNotFound (toName <$> qn)
+            _ -> throwIO $ DuplicateDeclAfterDesugar modName (toName typeName)
+
+instance
+    ( SupportsQuery QueryRequiredDeclarationByName ast
+    , Typeable ast
+    , RUnlocate ast
+    , IntrospectableAnnotations ast
+    ) =>
+    SupportsQuery DeclarationAnnotations ast
+    where
+    query qn = do
+        decl <- Rock.fetch $ RequiredDeclarationByName @ast qn
+        let body =
+                decl
+                    ^. _Unwrapped
+                    % rUnlocated @_ @ast @(Declaration' ast)
+                    % field' @"body"
+                    % _Unwrapped
+                    % rUnlocated @_ @ast @(DeclarationBody' ast)
+        case body of
+            Value{_valueAnnotations = annotations} -> pure (getAnnotations @ast @ForValueDecl (annotations ^. _Unwrapped))
+            ValueTypeDef _ _ annotations -> pure (getAnnotations @ast @ForValueDecl (annotations ^. _Unwrapped)) -- i am fairly sure this branch should never be hit
+            TypeDeclaration{typeAnnotations = annotations} -> pure (getAnnotations @ast @ForTypeDecl (annotations ^. field' @"typeDeclAnnotations"))
+
+instance
+    ( SupportsQuery QueryDeclarationByName ast
+    , Subset
+        (QueryEffectsOf QueryDeclarationByName ast)
+        (QueryEffectsOf QueryRequiredDeclarationByName ast)
+    , HasMinimumQueryEffects (QueryEffectsOf QueryRequiredDeclarationByName ast)
+    , Rock.Rock Query :> QueryEffectsOf QueryRequiredDeclarationByName ast
+    , Typeable ast
+    ) =>
+    SupportsQuery QueryRequiredDeclarationByName ast
+    where
+    type QuerySpecificEffectsOf QueryRequiredDeclarationByName ast = QuerySpecificEffectsOf QueryDeclarationByName ast
+    query name = do
+        mDecl <- Rock.fetch $ DeclarationByName @ast name
+        case mDecl of
+            Just decl -> pure decl
+            Nothing -> throwIO $ RequiredDeclNotFound name
+
+instance
+    ( Typeable ast
+    , RUnlocate ast
+    , SupportsQuery DeclarationAnnotations ast
+    , SupportsQuery QueryConstructorDeclaration ast
+    , annName ~ Qualified TypeName
+    , Select AnnotationName ast ~ annName
+    , Select ConRef ast ~ annName
+    , Ord annName
+    , Hashable annName
+    , CleanupLocated (Located annName) ~ Located annName
+    , CleanupLocated
+        (ASTLocate' ast (Select (ASTName ForType) ast))
+        ~ CleanupLocated (ASTLocate' ast (Qualified TypeName))
+    ) =>
+    SupportsQuery DeclarationAnnotationsOfType ast
+    where
+    type QuerySpecificEffectsOf DeclarationAnnotationsOfType ast = StandardQueryError ast
+    query (declName@(Qualified name modName), annName) = do
+        annotations <- Rock.fetch $ DeclarationAnnotations @ast (Qualified name modName)
+
+        fmap catMaybes $ for annotations $ \ann -> do
+            let name = ann ^. field' @"annotationName" % rUnlocated @_ @ast @(Select AnnotationName ast)
+            annotationDecl <- Rock.fetch (ConstructorDeclaration @ast name)
+
+            let body =
+                    annotationDecl
+                        ^. _Unwrapped
+                        % rUnlocated @_ @ast @(Declaration' ast)
+                        % field' @"body"
+                        % _Unwrapped
+                        % rUnlocated @_ @ast @(DeclarationBody' ast)
+            case body of
+                TypeDeclaration{_typeDeclarationName = tName} | tName ^. rUnlocated @_ @ast @annName == annName -> pure (Just ann)
+                _ -> pure Nothing

--- a/src/Elara/SCC.hs
+++ b/src/Elara/SCC.hs
@@ -12,9 +12,11 @@ import Elara.AST.Generic.Common
 import Elara.AST.Generic.Types
 import Elara.AST.Name
 import Elara.AST.Region (Located (..), unlocated)
+import Elara.AST.Select
 import Elara.AST.Shunted
 import Elara.AST.VarRef
 import Elara.Error (runErrorOrReport)
+import Elara.Query (QueryType (QueryRequiredDeclarationByName), SupportsQuery)
 import Elara.Query qualified
 import Elara.Query.Effects (ConsQueryEffects)
 import Elara.SCC.Type
@@ -23,12 +25,13 @@ import Optics
 import Rock qualified
 
 runFreeVarsQuery ::
+    SupportsQuery QueryRequiredDeclarationByName Shunted =>
     Qualified VarName ->
     Eff
         (ConsQueryEffects '[Rock.Rock Elara.Query.Query])
         (HashSet (Qualified VarName))
 runFreeVarsQuery name = do
-    declaration <- runErrorOrReport @ShuntError $ Rock.fetch (Elara.Query.ShuntedDeclarationByName (NVarName <$> name))
+    declaration <- runErrorOrReport @ShuntError $ Rock.fetch (Elara.Query.RequiredDeclarationByName @Shunted (NVarName <$> name))
 
     let body = declaration ^. _Unwrapped % unlocated % field' @"body" % _Unwrapped % unlocated
 

--- a/src/Elara/SCC.hs
+++ b/src/Elara/SCC.hs
@@ -20,6 +20,7 @@ import Elara.Query (QueryType (QueryRequiredDeclarationByName), SupportsQuery)
 import Elara.Query qualified
 import Elara.Query.Effects (ConsQueryEffects)
 import Elara.SCC.Type
+import Elara.Shunt ()
 import Elara.Shunt.Error (ShuntError)
 import Optics
 import Rock qualified

--- a/src/Elara/Shunt.hs
+++ b/src/Elara/Shunt.hs
@@ -127,12 +127,12 @@ createOpTable = execState mempty . traverseModule_ addDeclsToOpTable'
 
 addDeclsToOpTable' :: _ => Declaration Renamed -> Eff r ()
 addDeclsToOpTable' (Declaration (Located _ decl)) = case decl ^. field' @"body" % _Unwrapped % unlocated of
-    Value{_valueName, _valueAnnotations = (ValueDeclAnnotations (Just fixity))} ->
+    Value{_valueName, _valueAnnotations = (ValueDeclAnnotations (Just fixity) a)} ->
         let nameRef = Global $ IgnoreLocation (NVarName <<$>> _valueName)
          in modify $ Map.insert nameRef (infixDeclToOpInfo fixity)
-    Value{_valueName, _valueAnnotations = (ValueDeclAnnotations Nothing)} -> do
+    Value{_valueName, _valueAnnotations = (ValueDeclAnnotations Nothing a)} -> do
         debugPretty $ "No fixity for value declaration: " <> pretty _valueName
-    TypeDeclaration name _ _ (TypeDeclAnnotations (Just fixity) NoFieldValue) ->
+    TypeDeclaration name _ _ (TypeDeclAnnotations (Just fixity) NoFieldValue a) ->
         let nameRef = Global $ IgnoreLocation (NTypeName <<$>> name)
          in modify $ Map.insert nameRef (infixDeclToOpInfo fixity)
     _ -> pass

--- a/src/Elara/Shunt.hs
+++ b/src/Elara/Shunt.hs
@@ -92,7 +92,7 @@ runShuntedDeclarationByNameQuery (Qualified name modName) = do
 runGetOpInfoQuery :: IgnoreLocVarRef Name -> Eff (ConsQueryEffects '[Eff.Writer (Set ShuntWarning), Rock Elara.Query.Query]) (Maybe OpInfo)
 runGetOpInfoQuery (Global (IgnoreLocation (Located _ (Qualified name modName)))) = do
     -- I would love to be able to use ShuntedDeclarationByName but it will recurse forever :(
-    todo
+    pure Nothing
 -- mod <- runErrorOrReport @RenameError $ Rock.fetch $ Elara.Query.RenamedModule modName
 -- let matchingBodies =
 --         mod

--- a/src/Elara/Shunt/Error.hs
+++ b/src/Elara/Shunt/Error.hs
@@ -30,7 +30,7 @@ instance ReportableError ShuntError where
 
 data ShuntWarning
     = UnknownPrecedence OpTable RenamedDeclarationBody
-    deriving (Eq, Ord, Show)
+    deriving (Show, Eq, Ord)
 
 instance ReportableError ShuntWarning where
     report (UnknownPrecedence opTable lOperator) = do

--- a/src/Elara/Shunt/Error.hs
+++ b/src/Elara/Shunt/Error.hs
@@ -1,6 +1,7 @@
 module Elara.Shunt.Error where
 
 import Elara.AST.Generic.Types
+import Elara.AST.Name
 import Elara.AST.Region (HasSourceRegion (sourceRegion), sourceRegionToDiagnosePosition)
 import Elara.AST.Renamed (RenamedBinaryOperator, RenamedDeclarationBody)
 import Elara.Data.Pretty
@@ -11,6 +12,7 @@ import Error.Diagnose
 
 data ShuntError
     = SamePrecedenceError !(RenamedBinaryOperator, OpInfo) !(RenamedBinaryOperator, OpInfo)
+    | UnknownOperator !Name !ModuleName
     deriving (Show)
 
 instance Exception ShuntError

--- a/src/Elara/ToCore.hs
+++ b/src/Elara/ToCore.hs
@@ -240,7 +240,7 @@ moduleToCore m'@(Module (Located _ m)) = debugWithResult ("Converting module: " 
     decls <- fmap concat $ for (allEntriesRevTopologically declGraph) $ \decl -> do
         case decl ^. _Unwrapped % unlocated % field' @"body" % _Unwrapped % unlocated of
             Value{} -> pure []
-            TypeDeclaration n tvs (Located _ (ADT ctors)) (TypeDeclAnnotations _ kind _) -> debugWith ("Type decl: " <+> pretty n) $ do
+            TypeDeclaration n tvs (Located _ (ADT ctors)) (TypeDeclAnnotations kind _) -> debugWith ("Type decl: " <+> pretty n) $ do
                 let cleanedTypeDeclName = nameText <$> (n ^. unlocated)
                 let tyCon =
                         TyCon
@@ -273,7 +273,7 @@ moduleToCore m'@(Module (Located _ m)) = debugWithResult ("Converting module: " 
                             (tvs ^.. each % unlocated % to mkTypeVar)
                             (CoreDataDecl tyCon (toList ctors''))
                     ]
-            TypeDeclaration n tvs (Located _ (Alias (t, _))) (TypeDeclAnnotations _ kind _) -> do
+            TypeDeclaration n tvs (Located _ (Alias (t, _))) (TypeDeclAnnotations kind _) -> do
                 todo
 
     sccs <- buildModuleSCCs m'

--- a/src/Elara/ToCore.hs
+++ b/src/Elara/ToCore.hs
@@ -14,7 +14,7 @@ import Elara.AST.Generic.Common (NoFieldValue (..))
 import Elara.AST.Module (Module (Module))
 import Elara.AST.Name (ModuleName, Name (..), NameLike (..), Qualified (..), TypeName (..), VarName)
 import Elara.AST.Region (Located (Located), SourceRegion, unlocated)
-import Elara.AST.Select (LocatedAST (Typed))
+import Elara.AST.Select (ASTSelector (..), LocatedAST (Typed))
 import Elara.AST.StripLocation
 import Elara.AST.Typed
 import Elara.AST.VarRef (VarRef' (Global, Local), varRefVal)
@@ -240,7 +240,7 @@ moduleToCore m'@(Module (Located _ m)) = debugWithResult ("Converting module: " 
     decls <- fmap concat $ for (allEntriesRevTopologically declGraph) $ \decl -> do
         case decl ^. _Unwrapped % unlocated % field' @"body" % _Unwrapped % unlocated of
             Value{} -> pure []
-            TypeDeclaration n tvs (Located _ (ADT ctors)) (TypeDeclAnnotations _ kind) -> debugWith ("Type decl: " <+> pretty n) $ do
+            TypeDeclaration n tvs (Located _ (ADT ctors)) (TypeDeclAnnotations _ kind _) -> debugWith ("Type decl: " <+> pretty n) $ do
                 let cleanedTypeDeclName = nameText <$> (n ^. unlocated)
                 let tyCon =
                         TyCon
@@ -273,7 +273,7 @@ moduleToCore m'@(Module (Located _ m)) = debugWithResult ("Converting module: " 
                             (tvs ^.. each % unlocated % to mkTypeVar)
                             (CoreDataDecl tyCon (toList ctors''))
                     ]
-            TypeDeclaration n tvs (Located _ (Alias (t, _))) (TypeDeclAnnotations _ kind) -> do
+            TypeDeclaration n tvs (Located _ (Alias (t, _))) (TypeDeclAnnotations _ kind _) -> do
                 todo
 
     sccs <- buildModuleSCCs m'
@@ -282,7 +282,7 @@ moduleToCore m'@(Module (Located _ m)) = debugWithResult ("Converting module: " 
         sccToCore members
     pure $ CoreModule name (decls <> valueDecls)
 
-mkTypeVar :: Select "TypeVar" 'Typed -> Core.TypeVariable
+mkTypeVar :: Select ASTTypeVar 'Typed -> Core.TypeVariable
 mkTypeVar tv = TypeVariable tv TypeKind
 
 polytypeToCore :: HasCallStack => InnerToCoreC r => Type.Polytype SourceRegion -> Eff r Core.Type

--- a/src/Elara/TypeInfer.hs
+++ b/src/Elara/TypeInfer.hs
@@ -316,10 +316,7 @@ inferDeclaration (Declaration ld) = do
                     ctors' <- traverse inferCtor ctors
                     let ann' =
                             Generic.TypeDeclAnnotations
-                                { infixTypeDecl =
-                                    Generic.coerceInfixDeclaration
-                                        <$> anns.infixTypeDecl
-                                , kindAnn = kind
+                                { kindAnn = kind
                                 , typeDeclAnnotations = NoFieldValue
                                 }
                     pure

--- a/src/Elara/TypeInfer.hs
+++ b/src/Elara/TypeInfer.hs
@@ -320,6 +320,7 @@ inferDeclaration (Declaration ld) = do
                                     Generic.coerceInfixDeclaration
                                         <$> anns.infixTypeDecl
                                 , kindAnn = kind
+                                , typeDeclAnnotations = NoFieldValue
                                 }
                     pure
                         ( TypeDeclaration

--- a/src/Elara/TypeInfer.hs
+++ b/src/Elara/TypeInfer.hs
@@ -42,7 +42,9 @@ import Elara.Error (runErrorOrReport)
 import Elara.Logging (StructuredDebug, debug, debugWith, debugWithResult)
 import Elara.Query (Query (..), QueryType (..), SupportsQuery)
 import Elara.Query.Effects
+import Elara.Rules.Generic ()
 import Elara.SCC.Type (SCCKey, sccKeyToSCC)
+import Elara.Shunt ()
 import Elara.Shunt.Error (ShuntError)
 import Elara.TypeInfer.ConstraintGeneration
 import Elara.TypeInfer.Convert (TypeConvertError, astTypeToGeneralisedInferType, astTypeToInferType, astTypeToInferTypeWithKind)

--- a/src/Elara/TypeInfer/Type.hs
+++ b/src/Elara/TypeInfer/Type.hs
@@ -4,6 +4,7 @@ module Elara.TypeInfer.Type where
 import Control.Lens (cons)
 import Data.Kind qualified as Kind
 import Data.Map qualified as Map
+import Data.Typeable
 import Elara.AST.Name
 import Elara.AST.Region (SourceRegion, generatedSourceRegion, spanningRegion)
 import Elara.Data.Pretty (Pretty (..), hsep, parens)
@@ -149,18 +150,20 @@ substitution = Substitution . one
 class Substitutable (a :: Kind.Type -> Kind.Type) loc where
     substitute :: UniqueTyVar -> Monotype loc -> a loc -> a loc
 
+    -- | Apply an entire substitution to a type, recursively until a fixed point is reached
     substituteAll :: Eq (a loc) => Substitution loc -> a loc -> a loc
-    substituteAll (Substitution s) a =
-        let subst = foldr (uncurry substitute) a (Map.toList s)
-         in if subst == a then a else substituteAll (Substitution s) subst
 
--- instance Substitutable Type where
---     substitute tv t (Forall tv' c m) = Forall tv' (substitute tv t c) (substitute tv t m)
+-- we keep this default impl disabled by default to encourage writing custom efficient implementations
+-- substituteAll (Substitution s) a = let subst = foldr (uncurry substitute) a (Map.toList s) in if subst == a then a else defaultSubstituteAll (Substitution s) subst -- recursively apply until we reach a fixed point
 
-instance Substitutable Constraint loc where
+instance Eq loc => Substitutable Constraint loc where
     substitute _ _ (EmptyConstraint l) = EmptyConstraint l
     substitute tv t (Conjunction l c1 c2) = Conjunction l (substitute tv t c1) (substitute tv t c2)
     substitute tv t (Equality l m1 m2) = Equality l (substitute tv t m1) (substitute tv t m2)
+
+    substituteAll _ (EmptyConstraint l) = EmptyConstraint l
+    substituteAll s (Conjunction l c1 c2) = Conjunction l (substituteAll s c1) (substituteAll s c2)
+    substituteAll s (Equality l m1 m2) = Equality l (substituteAll s m1) (substituteAll s m2)
 
 instance Substitutable Monotype loc where
     substitute _ _ (TypeVar loc (SkolemVar v)) = TypeVar loc (SkolemVar v)
@@ -169,6 +172,18 @@ instance Substitutable Monotype loc where
     substitute _ _ (Scalar loc s) = Scalar loc s
     substitute tv t (TypeConstructor loc dc ts) = TypeConstructor loc dc (substitute tv t <$> ts)
     substitute tv t (Function loc t1 t2) = Function loc (substitute tv t t1) (substitute tv t t2)
+
+    substituteAll (Substitution m) t@(TypeVar loc tv) = case tv of
+        SkolemVar v -> TypeVar loc (SkolemVar v) -- skolems are rigid
+        UnificationVar v ->
+            -- make sure we recursively apply substitutions until we reach a fixed point
+            let r = case Map.lookup v m of
+                    Just t' -> t'
+                    Nothing -> TypeVar loc (UnificationVar v)
+             in if r == t then t else substituteAll (Substitution m) r
+    substituteAll _ (Scalar loc sc) = Scalar loc sc
+    substituteAll s (TypeConstructor loc dc ts) = TypeConstructor loc dc (substituteAll s <$> ts)
+    substituteAll s (Function loc t1 t2) = Function loc (substituteAll s t1) (substituteAll s t2)
 
 instance Substitutable Substitution loc where
     substitute tv t (Substitution s) = Substitution (Map.insert tv t s)

--- a/src/Elara/TypeInfer/Type.hs
+++ b/src/Elara/TypeInfer/Type.hs
@@ -1,12 +1,10 @@
 -- | Types used by the type inference engine
 module Elara.TypeInfer.Type where
 
-import Control.Lens (cons)
 import Data.Kind qualified as Kind
 import Data.Map qualified as Map
-import Data.Typeable
 import Elara.AST.Name
-import Elara.AST.Region (SourceRegion, generatedSourceRegion, spanningRegion)
+import Elara.AST.Region (SourceRegion, generatedSourceRegion)
 import Elara.Data.Pretty (Pretty (..), hsep, parens)
 import Elara.Data.Pretty.Styles qualified as Style
 import Elara.TypeInfer.Unique

--- a/src/Print.hs
+++ b/src/Print.hs
@@ -52,3 +52,6 @@ debugPretty = traceM . toString . prettyToText
 
 debugWithResult :: (Show a1, Show a2) => a1 -> a2 -> a2
 debugWithResult name res = trace (show name <> " -> " <> show res) res
+
+tracePretty :: Pretty a => a -> b -> b
+tracePretty val = trace (toString $ prettyToText val)

--- a/stdlib/prim.elr
+++ b/stdlib/prim.elr
@@ -14,6 +14,11 @@ type Tuple2 a b = Tuple2 a b
 
 type Ordering = LT | EQ | GT
 
+type Associativity = 
+    LeftAssociative
+
+type Fixity = Fixity Int
+
 #LeftAssociative #Fixity 6 
 def (+) : Int -> Int -> Int
 let (+) = elaraPrimitive "+"

--- a/stdlib/prim.elr
+++ b/stdlib/prim.elr
@@ -14,7 +14,8 @@ type Tuple2 a b = Tuple2 a b
 
 type Ordering = LT | EQ | GT
 
-
+@LeftAssociative
+@Fixity(6)
 def (+) : Int -> Int -> Int
 let (+) = elaraPrimitive "+"
 

--- a/stdlib/prim.elr
+++ b/stdlib/prim.elr
@@ -14,8 +14,7 @@ type Tuple2 a b = Tuple2 a b
 
 type Ordering = LT | EQ | GT
 
-@LeftAssociative
-@Fixity(6)
+#LeftAssociative #Fixity 6 
 def (+) : Int -> Int -> Int
 let (+) = elaraPrimitive "+"
 

--- a/test/Arbitrary/Names.hs
+++ b/test/Arbitrary/Names.hs
@@ -67,7 +67,7 @@ genOpText =
         Gen.filter notComment $
             Gen.text (Range.linear 1 4) (Gen.choice opChars)
   where
-    notReservedOp = (`Set.notMember` ["@", "=", ".", "\\", "=>", "->", "<-", "|"])
+    notReservedOp = (`Set.notMember` ["@", "#", "=", ".", "\\", "=>", "->", "<-", "|"])
     notComment = not . Text.isPrefixOf "--"
     opChars = pure <$> ['!', '#', '$', '%', '&', '*', '+', '.', '/', '\\', '<', '>', '=', '?', '@', '^', '|', '-', '~']
 


### PR DESCRIPTION
This will be expanded on greatly in the future but currently gives us a "no-magic" way of describing operator fixity and associativity at last!

Eg: 
```
#LeftAssociative 
#Fixity 6 
def (+) : Int -> Int -> Int
```

The shunter is able to recognise these annotations and process them correctly

This PR also makes some quite substantial refactors to the query system, adding ast-parametric queries to remove some duplicated code