### PR TITLE
🧹 [code health improvement] Inefficient token consumption in located parser

### DIFF
--- a/src/Elara/Parse.hs
+++ b/src/Elara/Parse.hs
@@ -79,4 +79,4 @@ getParsedModuleQuery mn = do
         else pure $ parsed & _Unwrapped % unlocated % field' @"name" % unlocated .~ mn
 
 createTokenStream :: Text -> [Lexeme] -> TokenStream
-createTokenStream i tokens = TokenStream i tokens False
+createTokenStream i tokens = TokenStream i tokens False 0

--- a/src/Elara/Parse/Primitives.hs
+++ b/src/Elara/Parse/Primitives.hs
@@ -45,7 +45,7 @@ ignoringIndents p = do
     void $ optional (token_ TokenDedent) -- this can get leftover because p wouldn't have consumed it
     pure r
 
-{- | A parser that records the location information of the tokens it consumes. -}
+-- | A parser that records the location information of the tokens it consumes.
 located :: Parser a -> Parser (Located a)
 located p = do
     startState <- stateInput <$> getParserState

--- a/src/Elara/Parse/Primitives.hs
+++ b/src/Elara/Parse/Primitives.hs
@@ -45,17 +45,14 @@ ignoringIndents p = do
     void $ optional (token_ TokenDedent) -- this can get leftover because p wouldn't have consumed it
     pure r
 
-{- | A parser that records the location information of the tokens it consumes.
-TODO this is not going to perform very well as it's O(n) in the total number of input tokens
-A future solution will be to store the number of tokens consumed in the 'TokenStream' and use that to calculate
-the spanning region, but that's effort at the moment.
--}
+{- | A parser that records the location information of the tokens it consumes. -}
 located :: Parser a -> Parser (Located a)
 located p = do
-    startTokens <- tokenStreamTokens . stateInput <$> getParserState
+    startState <- stateInput <$> getParserState
     val <- p
-    endStream <- tokenStreamTokens . stateInput <$> getParserState
-    let diff = length startTokens - length endStream
+    endState <- stateInput <$> getParserState
+    let startTokens = tokenStreamTokens startState
+    let diff = tokensConsumed endState - tokensConsumed startState
     let tokensDiff = take diff startTokens
     let tokensRegion = case tokensDiff of
             [] -> error "empty?"

--- a/src/Elara/Parse/Stream.hs
+++ b/src/Elara/Parse/Stream.hs
@@ -16,6 +16,8 @@ data TokenStream = TokenStream
     -- ^ The list of tokens remaining to be parsed
     , skipIndents :: Bool
     -- ^ Whether to skip Indent tokens encountered during parsing
+    , tokensConsumed :: !Int
+    -- ^ The number of tokens consumed from the stream
     }
     deriving (Show, Eq)
 
@@ -31,26 +33,26 @@ instance Stream TokenStream where
     chunkLength Proxy = length
     chunkEmpty Proxy = null
 
-    take1_ stream@(TokenStream _str tokens skip)
-        | skip = case dropWhile (isIndent . view unlocated) tokens of
-            [] -> Nothing
-            (t : ts) -> Just (t, stream{tokenStreamTokens = ts})
+    take1_ (TokenStream str tokens skip consumed)
+        | skip = case span (isIndent . view unlocated) tokens of
+            (_, []) -> Nothing
+            (skipped, t : ts) -> Just (t, TokenStream str ts skip (consumed + length skipped + 1))
         | otherwise = case tokens of
             [] -> Nothing
-            (t : ts) -> Just (t, stream{tokenStreamTokens = ts})
+            (t : ts) -> Just (t, TokenStream str ts skip (consumed + 1))
 
-    takeN_ n (TokenStream str s skipIndents)
-        | n <= 0 = Just ([], TokenStream str s skipIndents)
+    takeN_ n (TokenStream str s skipIndents consumed)
+        | n <= 0 = Just ([], TokenStream str s skipIndents consumed)
         | null s = Nothing
         | otherwise =
-            let (x, s') = takeWhile_ (const True) (TokenStream str s skipIndents)
+            let (x, s') = takeWhile_ (const True) (TokenStream str s skipIndents consumed)
              in case takeN_ (n - length x) s' of
                     Nothing -> Nothing
                     Just (xs, s'') -> Just (x ++ xs, s'')
 
-    takeWhile_ f (TokenStream str s skipIndents) =
+    takeWhile_ f (TokenStream str s skipIndents consumed) =
         let (x, s') = span f s
-         in (x, TokenStream str s' skipIndents) -- Again, preserve 'str'
+         in (x, TokenStream str s' skipIndents (consumed + length x)) -- Again, preserve 'str'
 
 instance VisualStream TokenStream where
     showTokens Proxy =
@@ -71,6 +73,7 @@ instance TraversableStream TokenStream where
                     { tokenStreamInput = fullText
                     , tokenStreamTokens = postLexemes
                     , skipIndents = pstateInput.skipIndents
+                    , tokensConsumed = pstateInput.tokensConsumed + length preLexemes
                     }
             , pstateOffset = max pstateOffset o
             , pstateSourcePos = newSourcePos

--- a/test/Boilerplate.hs
+++ b/test/Boilerplate.hs
@@ -281,7 +281,7 @@ parseExprWith ::
     [Elara.Lexer.Token.Lexeme] ->
     Eff '[StructuredDebug] (Either (WParseErrorBundle TokenStream ElaraParseError) a)
 parseExprWith parser fp source tokens = do
-    let tokenStream = TokenStream source tokens False
+    let tokenStream = TokenStream source tokens False 0
     first WParseErrorBundle <$> runParserT parser fp tokenStream
 
 -- | Create an OpLookup from the fake operator table

--- a/test/Parse/Common.hs
+++ b/test/Parse/Common.hs
@@ -64,7 +64,7 @@ lexAndParse ::
 lexAndParse parser source = do
     let fp = "<tests>"
     tokens <- evalEither $ runPureEff $ runError $ ignoreStructuredDebug $ readTokensWith (FileContents fp (toText source))
-    let tokenStream = TokenStream (toText source) tokens False
+    let tokenStream = TokenStream (toText source) tokens False 0
     pure $ parseWith parser fp (toText source) tokenStream
 
 shouldParsePattern :: MonadTest m => Text -> Pattern UnlocatedFrontend -> m ()


### PR DESCRIPTION
🎯 **What:** Improved the token consumption calculation inside the `located` parser to avoid $O(N)$ list length computations for every invocation. Added `tokensConsumed` to the parsing `TokenStream`.
💡 **Why:** Calculates token spanning region efficiently in $O(1)$ length diffing and bounded $O(diff)$ element fetching, improving parser performance and maintainability.
✅ **Verification:** Verified that skipped indents are correctly factored in by tracking their length and incrementing the `tokensConsumed` counter correctly in `Stream` and `TraversableStream` instances.
✨ **Result:** Avoids quadratic $O(N^2)$ traversal in loops containing `located`.

---
*PR created automatically by Jules for task [17487099410370497933](https://jules.google.com/task/17487099410370497933) started by @bristermitten*